### PR TITLE
fix for #91

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -8,15 +8,18 @@ let { ensureUser } = require("../helpers/user");
 
 async function getUserById(req, userId, res) {
   try {
-    const user = await db.oneOrNone(sql("../sql/user_by_id.sql"), {
+    const result = await db.oneOrNone(sql("../sql/user_by_id.sql"), {
       userId: userId,
       language: req.params.language || "en"
     });
-    console.log("GOT USER", user);
-    res.status(200).json({ OK: true, data: user });
+    res.status(200).json({ OK: true, data: result.user });
   } catch (error) {
     log.error("Exception in GET /user/%s => %s", req.params.userId, error);
-    res.status(500).json({ OK: false, error: error });
+    if (error.message && error.message == "No data returned from the query.") {
+      res.status(404).json({ OK: false });
+    } else {
+      res.status(500).json({ OK: false, error: error });
+    }
   }
 }
 

--- a/api/sql/user_by_id.sql
+++ b/api/sql/user_by_id.sql
@@ -54,16 +54,18 @@ UNION
     bookmarks.bookmarktype = 'organization'
 )
 
+SELECT row_to_json(user_row) as user
+FROM (
 SELECT
 	users.name,
 	users.id,
   users.join_date,
   users.picture_url,
   'user' as type,
-	to_json(COALESCE(cases_authored, '{}')) cases,
-	to_json(COALESCE(methods_authored, '{}')) methods,
-	to_json(COALESCE(organizations_authored, '{}')) organizations,
-  to_json(COALESCE(ARRAY(SELECT ROW(id, type, title, lead_image, post_date, updated_date)::object_reference FROM user_bookmarks), '{}')) bookmarks
+	COALESCE(cases_authored, '{}') cases,
+	COALESCE(methods_authored, '{}') methods,
+	COALESCE(organizations_authored, '{}') organizations,
+  COALESCE(ARRAY(SELECT ROW(id, type, title, lead_image, post_date, updated_date)::object_reference FROM user_bookmarks), '{}') bookmarks
 FROM
 	users LEFT JOIN
 	(
@@ -116,4 +118,5 @@ FROM
 	) AS org_authors  ON org_authors.user_id = users.id
 WHERE
 	users.id = ${userId}
+) user_row
 ;

--- a/migrations/migration_018.sql
+++ b/migrations/migration_018.sql
@@ -1,0 +1,9 @@
+DROP TYPE object_reference;
+CREATE TYPE object_reference AS (
+    id INTEGER,
+    type TEXT,
+    title TEXT,
+    lead_image attachment,
+    updated_date timestamptz,
+    post_date timestamptz
+);

--- a/setup.sql
+++ b/setup.sql
@@ -268,3 +268,4 @@ CREATE TABLE bookmarks (
 \include 'migrations/migration_015.sql'
 \include 'migrations/migration_016.sql'
 \include 'migrations/migration_017.sql'
+\include 'migrations/migration_018.sql'


### PR DESCRIPTION
We had `lead_image` defined in `object_reference` as `TEXT` rather than as `attachment`. So lead_image was broken everywhere, not just for users.

Did some other cleanup while I was in there.