### PR TITLE
parses whitespace now on server-side, dafaults to AND search

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -238,7 +238,7 @@ async function full_text_search(res, query, language, page) {
     });
     res.status(200).json({ OK: true, results: objList });
   } catch (error) {
-    log.error("Exception in GET /search/v2/", error);
+    log.error("Exception in GET /search/", error);
     res.status(500).json({ OK: false, error: error });
   }
 }

--- a/api/sql/search.sql
+++ b/api/sql/search.sql
@@ -7,8 +7,8 @@
 
 SELECT id, type, title, lead_image, updated_date
 FROM search_index_${language:raw}
-WHERE document @@ to_tsquery('english', ${query})
-ORDER BY ts_rank(search_index_${language:raw}.document, to_tsquery('english', ${query})) DESC
+WHERE document @@ plainto_tsquery('english', ${query})
+ORDER BY ts_rank(search_index_${language:raw}.document, plainto_tsquery('english', ${query})) DESC
 OFFSET ${offset}
 LIMIT ${limit}
 ;

--- a/test/search.js
+++ b/test/search.js
@@ -125,7 +125,7 @@ describe("Search", () => {
     it("multi-word search", done => {
       chai
         .request(app)
-        .get("/search?query=Budget%20%26%20Participatory")
+        .get("/search?query=Budget Participatory")
         .set("Content-Type", "application/json")
         .set("Accept", "application/json")
         .send({})


### PR DESCRIPTION
Replaced `to_tsquery` with `plainto_tsquery` which turns whitespace into `&` between non-stopwords. This is an AND search, returning results which include both (or all) words, but not relying on word order. If we want to retain word order, we can use `phraseto_tsquery` which replaces whitespace with the FOLLOWED BY operator.

We can get more fancy, supporting AND, OR, quotation-grouping, and FOLLOWED BY, but it will require us to handle more of the parsing on our side (or exposing Postgres operators `&`, `|`, `>>` to the users).

Fixes #83.