### PR TITLE
Search results hotfix

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -79,14 +79,22 @@ const get_all_nouns = async (res, facets, page, language, orderBy) => {
       });
       return t.batch(query);
     });
-    let results = [].concat(
-      objLists.map(typeList => {
-        let objType = typeList.type;
-        typeList.hits.forEach(obj => obj.type = objType);
-        return typeList.hits;
-      })
-    );
-    res.status(200).json({ OK: true, results: results });
+    let results = objLists.map(typeList => {
+      if (!typeList) {
+        return [];
+      }
+      return typeList.map(function(obj) {
+        return {
+          id: obj.id,
+          type: obj.type,
+          title: obj.title,
+          lead_image: obj.lead_image,
+          updated_date: obj.updated_date
+        };
+      });
+    });
+    console.log("results: >> %s << ", JSON.stringify(results).slice(0, 100));
+    res.status(200).json({ OK: true, results: [].concat.apply([], results) });
   } catch (error) {
     log.error("Exception in GET /search/getAllForType", error);
     res.status(500).json({ error: error });

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -93,7 +93,6 @@ const get_all_nouns = async (res, facets, page, language, orderBy) => {
         };
       });
     });
-    console.log("results: >> %s << ", JSON.stringify(results).slice(0, 100));
     res.status(200).json({ OK: true, results: [].concat.apply([], results) });
   } catch (error) {
     log.error("Exception in GET /search/getAllForType", error);

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -57,7 +57,8 @@ const get_nouns_by_type = async (
       offset: (page - 1) * RESPONSE_LIMIT,
       order_by: orderBy
     });
-    res.status(200).json({ results: [{ type: objType, hits: objList }] });
+    objList.forEach(obj => obj.type = objType);
+    res.status(200).json({ OK: true, results: objList });
   } catch (error) {
     log.error("Exception in GET /search/getAllForType", error);
     res.status(500).json({ error: error });
@@ -78,22 +79,14 @@ const get_all_nouns = async (res, facets, page, language, orderBy) => {
       });
       return t.batch(query);
     });
-    res.status(200).json({
-      results: [
-        {
-          type: "case",
-          hits: objLists[0]
-        },
-        {
-          type: "method",
-          hits: objLists[1]
-        },
-        {
-          type: "organization",
-          hits: objLists[2]
-        }
-      ]
-    });
+    let results = [].concat(
+      objLists.map(typeList => {
+        let objType = typeList.type;
+        typeList.hits.forEach(obj => obj.type = objType);
+        return typeList.hits;
+      })
+    );
+    res.status(200).json({ OK: true, results: results });
   } catch (error) {
     log.error("Exception in GET /search/getAllForType", error);
     res.status(500).json({ error: error });

--- a/test/search.js
+++ b/test/search.js
@@ -63,9 +63,9 @@ describe("Search", () => {
         .send({})
         .end((err, res) => {
           res.should.have.status(200);
-          res.body.results.should.have.lengthOf(1);
-          res.body.results[0].type.should.equal("organization");
-          res.body.results[0].hits.should.have.lengthOf(17);
+          res.body.OK.should.equal(true);
+          res.body.results.should.have.lengthOf(17);
+          res.body.results.all.type.should.equal("organization");
           done();
         });
     });
@@ -101,9 +101,9 @@ describe("Search", () => {
         .send({})
         .end((err, res) => {
           res.should.have.status(200);
-          res.body.results.should.have.lengthOf(3);
-          res.body.results[0].type.should.equal("case");
-          res.body.results[0].hits.should.have.lengthOf(2);
+          res.body.OK.should.equal(true);
+          res.body.results.should.have.lengthOf(2);
+          // more testing
           done();
         });
     });

--- a/test/search.js
+++ b/test/search.js
@@ -65,7 +65,8 @@ describe("Search", () => {
           res.should.have.status(200);
           res.body.OK.should.equal(true);
           res.body.results.should.have.lengthOf(17);
-          res.body.results.all.type.should.equal("organization");
+          res.body.results.forEach(obj =>
+            obj.type.should.equal("organization"));
           done();
         });
     });
@@ -82,9 +83,9 @@ describe("Search", () => {
         .send({})
         .end((err, res) => {
           res.should.have.status(200);
+          res.body.OK.should.equal(true);
           res.body.results.should.have.lengthOf(1);
           res.body.results[0].type.should.equal("case");
-          res.body.results[0].hits.should.have.lengthOf(1);
           done();
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,13 +190,9 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
-ast-types@0.8.18:
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.18.tgz#c8b98574898e8914e9d8de74b947564a9fe929af"
-
-ast-types@0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.4.tgz#410d1f81890aeb8e0a38621558ba5869ae53c91b"
+ast-types@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.8.tgz#6cb6a40beba31f49f20928e28439fc14a3dab078"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -404,9 +400,9 @@ babel@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
 
-babylon@6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
+babylon@7.0.0-beta.8:
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
 
 babylon@^6.11.0, babylon@^6.15.0, babylon@^6.16.1:
   version "6.16.1"
@@ -662,7 +658,7 @@ color-name@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
 
-colors@1.0.x, colors@>=0.6.2:
+colors@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
@@ -1335,13 +1331,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-parser@0.40.0:
-  version "0.40.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.40.0.tgz#b3444742189093323c4319c4fe9d35391f46bcbc"
-  dependencies:
-    ast-types "0.8.18"
-    colors ">=0.6.2"
-    minimist ">=0.2.0"
+flow-parser@0.43.0:
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.43.0.tgz#e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7"
 
 for-each@~0.3.2:
   version "0.3.2"
@@ -2358,7 +2350,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@>=0.2.0, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
+minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -2678,9 +2670,9 @@ pg-minify@0.4:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/pg-minify/-/pg-minify-0.4.2.tgz#c75b4b5878960fb09c3b9a4d4eb1036aea7ea0e3"
 
-pg-promise@5.6.3:
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/pg-promise/-/pg-promise-5.6.3.tgz#76b1948f34309e55e325d0130eaad46d81486b80"
+pg-promise@5.6.5:
+  version "5.6.5"
+  resolved "https://registry.yarnpkg.com/pg-promise/-/pg-promise-5.6.5.tgz#63e7d23c321e38d5c23ac4bab7c850b925509177"
   dependencies:
     manakin "0.4"
     pg "5.1"
@@ -2763,16 +2755,16 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-0.22.0.tgz#7b37c4480d0858180407e5a8e13f0f47da7385d2"
+prettier@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.2.2.tgz#22d17c1132faaaea1f1d4faea31f19f7a1959f3e"
   dependencies:
-    ast-types "0.9.4"
+    ast-types "0.9.8"
     babel-code-frame "6.22.0"
-    babylon "6.15.0"
+    babylon "7.0.0-beta.8"
     chalk "1.1.3"
     esutils "2.0.2"
-    flow-parser "0.40.0"
+    flow-parser "0.43.0"
     get-stdin "5.0.1"
     glob "7.1.1"
     jest-validate "19.0.0"


### PR DESCRIPTION
This puts the return results from faceted searches into the same format as for full-text searches, pending their merger. It will return an array of cases, then methods, then organizations if the search type is ALL, rather than merging them by sort order (temporary). Also trimmed the return values: we get everything back from the database, but only return id/type/title/lead_image/updated_date over the wire.