### PR TITLE
add currently failing test on editing issues

### DIFF
--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -177,7 +177,7 @@ function getEditXById(type) {
             // DELETE / INSERT any needed rows for related_nouns
             const oldList = oldThing[key];
             const newList = newThing[key];
-            newList.forEach(x => x.id = x.id || x.value); // handle client returning value vs. id
+            newList.forEach(x => (x.id = x.id || x.value)); // handle client returning value vs. id
             const diff = diffRelatedList(oldList, newList);
             const relType = key.split("_")[1].slice(0, -1); // related_Xs => X
             const add = addRelatedList(
@@ -228,7 +228,7 @@ function getEditXById(type) {
               value: as.attachments(newThing[key])
             });
           } else {
-            let value = oldThing[key];
+            let value = newThing[key];
             let asValue = as.text;
             if (typeof value === "boolean") {
               asValue = as.value;

--- a/test/cases.js
+++ b/test/cases.js
@@ -104,7 +104,7 @@ async function setupRelatedObjectsMultiple() {
     });
 }
 
-describe.only("Cases", () => {
+describe("Cases", () => {
   describe("Lookup", () => {
     it("finds case 100", async () => {
       const res = await chai.getJSON("/case/100").send({});
@@ -202,7 +202,7 @@ describe.only("Cases", () => {
       the_case.bookmarked.should.equal(false);
     });
   });
-  describe.only("Get case with authentication", () => {
+  describe("Get case with authentication", () => {
     it("should not fail when logged in", async () => {
       try {
         const res = await chai
@@ -266,7 +266,7 @@ describe.only("Cases", () => {
       updatedCase3.body.should.equal("Third Body");
       updatedCase3.authors.length.should.equal(updatedCase2.authors.length + 1);
     });
-    it.only("Add case, then modify some fields", async () => {
+    it("Add case, then modify some fields", async () => {
       const res1 = await addBasicCase();
       res1.should.have.status(201);
       res1.body.OK.should.be.true;

--- a/test/cases.js
+++ b/test/cases.js
@@ -104,7 +104,7 @@ async function setupRelatedObjectsMultiple() {
     });
 }
 
-describe("Cases", () => {
+describe.only("Cases", () => {
   describe("Lookup", () => {
     it("finds case 100", async () => {
       const res = await chai.getJSON("/case/100").send({});
@@ -202,7 +202,7 @@ describe("Cases", () => {
       the_case.bookmarked.should.equal(false);
     });
   });
-  describe("Get case with authentication", () => {
+  describe.only("Get case with authentication", () => {
     it("should not fail when logged in", async () => {
       try {
         const res = await chai
@@ -265,6 +265,22 @@ describe("Cases", () => {
       updatedCase3.title.should.equal("Third Title");
       updatedCase3.body.should.equal("Third Body");
       updatedCase3.authors.length.should.equal(updatedCase2.authors.length + 1);
+    });
+    it.only("Add case, then modify some fields", async () => {
+      const res1 = await addBasicCase();
+      res1.should.have.status(201);
+      res1.body.OK.should.be.true;
+      res1.body.data.case_id.should.be.a("number");
+      const origCase = res1.body.object;
+      origCase.id.should.be.a("number");
+      origCase.id.should.equal(res1.body.data.case_id);
+      const res2 = await chai
+        .putJSON("/case/" + res1.body.data.case_id)
+        .set("Authorization", "Bearer " + tokens.user_token)
+        .send({ issue: "new issue" }); // empty update
+      res2.should.have.status(200);
+      const updatedCase1 = res2.body.data;
+      updatedCase1.issue.should.equal("new issue");
     });
     it("Add case, then modify lead image", async () => {
       const res1 = await addBasicCase();


### PR DESCRIPTION
@dethe, I'm seeing some failures when editing `issue` which are interesting.  With some debugging logs added, I see:

```
POST /case/new 201 1363.581 ms - -
newThing { issue: 'new issue' }
CHANGES [ { key: '"issue"', value: 'null' } ]
PUT /case/4754 200 1265.480 ms - -
      1) Add case, then modify some fields


  1 passing (3s)
  1 failing

  1) Cases Test edit API Add case, then modify some fields:
     TypeError: Cannot read property 'should' of null
      at it.only (test/cases.js:283:25)
      at process._tickDomainCallback (internal/process/next_tick.js:135:7)
```

Note that the `value` in that CHANGES line is the _old_ value. 