### PR TITLE
132 add links

### DIFF
--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -13,45 +13,6 @@ const {
   getThingByType_id_lang_userId
 } = require("../helpers/things");
 
-const empty_case = {
-  title: "",
-  body: "",
-  language: "en",
-  user_id: null,
-  original_language: "en",
-  issue: null,
-  communication_mode: null,
-  communication_with_audience: null,
-  content_country: null,
-  decision_method: null,
-  facetoface_online_or_both: null,
-  facilitated: null,
-  voting: "none",
-  number_of_meeting_days: null,
-  ongoing: false,
-  total_number_of_participants: null,
-  targeted_participant_demographic: "General Public",
-  kind_of_influence: null,
-  targeted_participants_public_role: "Lay Public",
-  targeted_audience: "General Public",
-  participant_selection: "Open to all",
-  specific_topic: null,
-  staff_type: null,
-  type_of_funding_entity: null,
-  typical_implementing_entity: null,
-  typical_sponsoring_entity: null,
-  who_else_supported_the_initiative: null,
-  who_was_primarily_responsible_for_organizing_the_initiative: null,
-  location: null,
-  lead_image_url: "",
-  other_images: "{}",
-  files: "{}",
-  videos: "{}",
-  tags: "{}",
-  featured: false,
-  bookmarked: false
-};
-
 /**
  * @api {get} /case/countsByCountry Get case counts for each country
  * @apiGroup Cases
@@ -215,17 +176,23 @@ router.post("/new", async function postNewCase(req, res) {
     const location = as.location(req.body.location);
     const videos = as.videos(req.body.vidURL);
     const lead_image = as.attachment(req.body.lead_image); // frontend isn't sending this yet
-    const thing = await db.one(
-      sql("../sql/create_case.sql"),
-      Object.assign({}, empty_case, {
-        title,
-        body,
-        location,
-        lead_image,
-        videos,
-        user_id
-      })
-    );
+    const issue = as.text(req.body.issue);
+    const specific_topic = as.text(req.body.specific_topic);
+    const tags = as.strings(req.body.tags);
+    const links = as.strings(req.body.links);
+    const thing = await db.one(sql("../sql/create_case.sql"), {
+      title,
+      body,
+      language,
+      issue,
+      specific_topic,
+      tags,
+      links,
+      location,
+      lead_image,
+      videos,
+      user_id
+    });
     // save related objects (needs thingid)
     const relCases = addRelatedList(
       "case",

--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -11,38 +11,6 @@ const {
   getThingByType_id_lang_userId
 } = require("../helpers/things");
 
-const empty_method = {
-  type: "method",
-  title: "",
-  body: "",
-  language: "en",
-  user_id: null,
-  original_language: "en",
-  best_for: null,
-  communication_mode: null,
-  decision_method: null,
-  facilitated: null,
-  governance_contribution: null,
-  issue_interdependency: null,
-  issue_polarization: null,
-  issue_technical_complexity: null,
-  kind_of_influence: null,
-  method_of_interaction: null,
-  public_interaction_method: null,
-  post_date: "now",
-  published: true,
-  typical_funding_source: null,
-  typical_implementing_entity: null,
-  typical_sponsoring_entity: null,
-  updated_date: "now",
-  lead_image_url: "",
-  other_images: "{}",
-  files: "{}",
-  videos: "{}",
-  tags: "{}",
-  featured: false
-};
-
 /**
  * @api {post} /method/new Create new method
  * @apiGroup Methods
@@ -88,16 +56,18 @@ router.post("/new", async function(req, res) {
     const user_id = req.user.user_id;
     const videos = as.videos(req.body.vidURL);
     const lead_image = as.attachment(req.body.lead_image); // frontend isn't sending this yet
-    const thing = await db.one(
-      sql("../sql/create_method.sql"),
-      Object.assign({}, empty_method, {
-        title,
-        body,
-        lead_image,
-        videos,
-        user_id
-      })
-    );
+    const tags = as.strings(req.body.tags);
+    const links = as.strings(req.body.links);
+    const thing = await db.one(sql("../sql/create_method.sql"), {
+      title,
+      body,
+      language,
+      lead_image,
+      videos,
+      tags,
+      links,
+      user_id
+    });
     const thingid = thing.thingid;
     // save related objects (needs thingid)
     const relCases = addRelatedList(

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -12,27 +12,6 @@ const {
   getThingByType_id_lang_userId
 } = require("../helpers/things");
 
-const empty_organization = {
-  type: "organization",
-  title: "",
-  body: "",
-  language: "en",
-  user_id: null,
-  original_language: "en",
-  executive_director: null,
-  post_date: "now",
-  published: true,
-  sector: null,
-  updated_date: "now",
-  location: null,
-  lead_image_url: "",
-  other_images: "{}",
-  files: "{}",
-  videos: "{}",
-  tags: "{}",
-  featured: false
-};
-
 /**
  * @api {post} /organization/new Create new organization
  * @apiGroup Organizations
@@ -77,19 +56,23 @@ router.post("/new", async function(req, res) {
     }
     const user_id = req.user.user_id;
     const location = as.location(req.body.location);
+    const issue = as.text(req.body.issue);
     const videos = as.videos(req.body.vidURL);
     const lead_image = as.attachment(req.body.lead_image); // frontend isn't sending this yet
-    const thing = await db.one(
-      sql("../sql/create_organization.sql"),
-      Object.assign({}, empty_organization, {
-        title,
-        body,
-        location,
-        lead_image,
-        videos,
-        user_id
-      })
-    );
+    const tags = as.strings(req.body.tags);
+    const links = as.strings(req.body.links);
+    const thing = await db.one(sql("../sql/create_organization.sql"), {
+      title,
+      body,
+      language,
+      issue,
+      location,
+      lead_image,
+      videos,
+      tags,
+      links,
+      user_id
+    });
     const thingid = thing.thingid;
     // save related objects (needs thingid)
     const relCases = addRelatedList(

--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -116,7 +116,7 @@ function videos(url, title) {
 // as.strings / as.tags (could be used as as.strings too
 function strings(strList) {
   if (!strList) {
-    return "{}";
+    return "'{}'";
   }
   return "ARRAY[" + strList.map(s => as.text(s)).join(", ") + "]::text[]";
 }

--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -116,7 +116,7 @@ function videos(url, title) {
 // as.strings / as.tags (could be used as as.strings too
 function strings(strList) {
   if (!strList) {
-    return "null";
+    return "{}";
   }
   return "ARRAY[" + strList.map(s => as.text(s)).join(", ") + "]::text[]";
 }

--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -200,7 +200,7 @@ function getEditXById(type) {
               key: as.name(key),
               value: as.location(newThing[key])
             });
-          } else if (key === "tags") {
+          } else if (["tags", "links"].includes(key)) {
             updatedThingFields.push({
               key: as.name(key),
               value: as.tags(newThing[key])

--- a/api/sql/create_case.sql
+++ b/api/sql/create_case.sql
@@ -14,17 +14,26 @@ WITH insert_case as (
     who_else_supported_the_initiative,
     who_was_primarily_responsible_for_organizing_the_initiative,
     location, lead_image, other_images,
-    files, videos, tags, featured
+    files, videos, tags, featured, links
   )
   VALUES
     (
-      'case', ${language}, null, null, null, null, null, null,
-      null, null, 'none', null, false, 'now',
-      true, 'now', null, 'now', 'General Public',
-      null, 'Lay Public', 'General Public',
-      'Open to all', null, null, null, null,
-      null, null, null, ${location:raw}, ${lead_image:raw},
-      '{}', '{}', ${videos:raw}, '{}', false
+      'case', ${language}, null, null,
+      null, null,
+      null, null,
+      null, null, 'none',
+      null, false, 'now',
+      true, 'now',
+      null, 'now',
+      null
+      null, null,
+      null, null, 
+      null, null, null,
+      null, null,
+      null,
+      null,
+      ${location:raw}, ${lead_image:raw}, '{}',
+      '{}', ${videos:raw}, '{}', false, '{}'
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/create_case.sql
+++ b/api/sql/create_case.sql
@@ -7,8 +7,8 @@ WITH insert_case as (
   VALUES
     (
       'case', ${language}, ${issue}, 'now', true, 'now',
-      ${specific_topic}, ${location:raw}, ${lead_image:raw}, '{}', '{}', ${videos:raw}, '${tags:raw}', 
-      false, '${links:raw}'
+      ${specific_topic}, ${location:raw}, ${lead_image:raw}, '{}', '{}', ${videos:raw}, ${tags:raw},
+      false, ${links:raw}
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/create_case.sql
+++ b/api/sql/create_case.sql
@@ -1,39 +1,14 @@
 WITH insert_case as (
   INSERT into cases (
-    type, original_language, issue, communication_mode,
-    communication_with_audience, content_country,
-    decision_method, end_date, facetoface_online_or_both,
-    facilitated, voting, number_of_meeting_days,
-    ongoing, post_date, published, start_date,
-    total_number_of_participants, updated_date,
-    targeted_participant_demographic,
-    kind_of_influence, targeted_participants_public_role,
-    targeted_audience, participant_selection,
-    specific_topic, staff_type, type_of_funding_entity,
-    typical_implementing_entity, typical_sponsoring_entity,
-    who_else_supported_the_initiative,
-    who_was_primarily_responsible_for_organizing_the_initiative,
-    location, lead_image, other_images,
-    files, videos, tags, featured, links
+    type, original_language, issue, post_date, published, updated_date,
+    specific_topic, location, lead_image, other_images, files, videos, tags,
+    featured, links
   )
   VALUES
     (
-      'case', ${language}, null, null,
-      null, null,
-      null, null,
-      null, null, 'none',
-      null, false, 'now',
-      true, 'now',
-      null, 'now',
-      null
-      null, null,
-      null, null, 
-      null, null, null,
-      null, null,
-      null,
-      null,
-      ${location:raw}, ${lead_image:raw}, '{}',
-      '{}', ${videos:raw}, '{}', false, '{}'
+      'case', ${language}, ${issue}, 'now', true, 'now',
+      ${specific_topic}, ${location:raw}, ${lead_image:raw}, '{}', '{}', ${videos:raw}, '${tags:raw}', 
+      false, '${links:raw}'
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/create_method.sql
+++ b/api/sql/create_method.sql
@@ -6,7 +6,7 @@ WITH insert_method as (
   VALUES
     (
       'method', ${language}, 'now', true, 'now',
-      ${lead_image:raw}, '{}', '{}', ${videos:raw}, '${tags:raw}', false, '{$links:raw}'
+      ${lead_image:raw}, '{}', '{}', ${videos:raw}, ${tags:raw}, false, ${links:raw}
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/create_method.sql
+++ b/api/sql/create_method.sql
@@ -1,22 +1,12 @@
 WITH insert_method as (
   INSERT into methods (
-    type, original_language, best_for, communication_mode,
-    decision_method, facilitated, governance_contribution, issue_interdependency,
-    issue_polarization, issue_technical_complexity, kind_of_influence,
-    method_of_interaction, public_interaction_method, post_date,
-    published, typical_funding_source, typical_implementing_entity,
-    typical_sponsoring_entity, updated_date,
+    type, original_language, post_date, published, updated_date,
     lead_image, other_images, files, videos, tags, featured, links
   )
   VALUES
     (
-      'method', ${language}, null, null,
-      null, null, null, null,
-      null, null, null,
-      null, null, 'now',
-      true, null, null,
-      null, 'now',
-      ${lead_image:raw}, '{}', '{}', ${videos:raw}, '{}', false, '{}'
+      'method', ${language}, 'now', true, 'now',
+      ${lead_image:raw}, '{}', '{}', ${videos:raw}, '${tags:raw}', false, '{$links:raw}'
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/create_method.sql
+++ b/api/sql/create_method.sql
@@ -1,21 +1,22 @@
 WITH insert_method as (
   INSERT into methods (
     type, original_language, best_for, communication_mode,
-    decision_method, facilitated, governance_contribution, issue_interdependency, issue_polarization,
-    issue_technical_complexity, kind_of_influence, method_of_interaction,
-    public_interaction_method, post_date,
+    decision_method, facilitated, governance_contribution, issue_interdependency,
+    issue_polarization, issue_technical_complexity, kind_of_influence,
+    method_of_interaction, public_interaction_method, post_date,
     published, typical_funding_source, typical_implementing_entity,
     typical_sponsoring_entity, updated_date,
-    lead_image, other_images,
-    files, videos, tags, featured
+    lead_image, other_images, files, videos, tags, featured, links
   )
   VALUES
     (
-      'method', ${language}, null, null, null, null, null, null,
-      null, null, null, null, null, 'now', true,
-      null, null, null, 'now',
-      ${lead_image:raw},
-      '{}', '{}', ${videos:raw}, '{}', false
+      'method', ${language}, null, null,
+      null, null, null, null,
+      null, null, null,
+      null, null, 'now',
+      true, null, null,
+      null, 'now',
+      ${lead_image:raw}, '{}', '{}', ${videos:raw}, '{}', false, '{}'
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/create_organization.sql
+++ b/api/sql/create_organization.sql
@@ -1,16 +1,15 @@
 WITH insert_organization as (
   INSERT into organizations (
-    type, original_language, executive_director, issue,
-    post_date, published,
-    sector, updated_date, location,
-    lead_image, other_images,
-    files, videos, tags, featured
+    type, original_language, executive_director, issue, post_date, published,
+    sector, updated_date, location, lead_image, other_images, files, videos,
+    tags, featured, links
   )
   VALUES
     (
-      'organization', ${language}, null, null, 'now', true, null, 'now', ${location:raw},
-      ${lead_image:raw},
-      '{}', '{}', ${videos:raw}, '{}', false
+      'organization', ${language}, null, null, 'now', true,
+      null, 'now', ${location:raw},
+      ${lead_image:raw}, '{}', '{}', ${videos:raw}, 
+      '{}', false, '{}'
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/create_organization.sql
+++ b/api/sql/create_organization.sql
@@ -9,7 +9,7 @@ WITH insert_organization as (
       'organization', ${language}, ${issue}, 'now', true,
       'now', ${location:raw},
       ${lead_image:raw}, '{}', '{}', ${videos:raw},
-      '${tags:raw}', false, '${links:raw}'
+      ${tags:raw}, false, ${links:raw}
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/create_organization.sql
+++ b/api/sql/create_organization.sql
@@ -1,15 +1,15 @@
 WITH insert_organization as (
   INSERT into organizations (
-    type, original_language, executive_director, issue, post_date, published,
-    sector, updated_date, location, lead_image, other_images, files, videos,
+    type, original_language, issue, post_date, published,
+    updated_date, location, lead_image, other_images, files, videos,
     tags, featured, links
   )
   VALUES
     (
-      'organization', ${language}, null, null, 'now', true,
-      null, 'now', ${location:raw},
-      ${lead_image:raw}, '{}', '{}', ${videos:raw}, 
-      '{}', false, '{}'
+      'organization', ${language}, ${issue}, 'now', true,
+      'now', ${location:raw},
+      ${lead_image:raw}, '{}', '{}', ${videos:raw},
+      '${tags:raw}', false, '${links:raw}'
     ) RETURNING id as thingid
 ),
 insert_author as (

--- a/api/sql/list_cases.sql
+++ b/api/sql/list_cases.sql
@@ -36,6 +36,8 @@ SELECT
     to_json(COALESCE(cases.files, '{}')) AS files,
     to_json(COALESCE(cases.videos, '{}')) AS videos,
     to_json(COALESCE(cases.tags, '{}')) AS tags,
+    cases.featured,
+    to_json(COALESCE(cases.links, '{}')) as links,
     localized_texts.body,
     localized_texts.title,
     to_json(author_list.authors) authors

--- a/api/sql/list_methods.sql
+++ b/api/sql/list_methods.sql
@@ -24,6 +24,8 @@ SELECT
     to_json(COALESCE(methods.files, '{}')) AS files,
     to_json(COALESCE(methods.videos, '{}')) AS videos,
     to_json(COALESCE(methods.tags, '{}')) AS tags,
+    methods.featured,
+    to_json(COALESCE(methods.links, '{}')) AS links,
     localized_texts.body,
     localized_texts.title,
     to_json(author_list.authors) AS authors

--- a/api/sql/list_organizations.sql
+++ b/api/sql/list_organizations.sql
@@ -14,6 +14,8 @@ SELECT
     to_json(COALESCE(organizations.files, '{}')) AS files,
     to_json(COALESCE(organizations.videos, '{}')) AS videos,
     to_json(COALESCE(organizations.tags, '{}')) AS tags,
+    organizations.featured,
+    to_json(COALESCE(organizations.links, '{}')) AS links,
     localized_texts.body,
     localized_texts.title,
     to_json(author_list.authors) AS authors

--- a/api/sql/thing_by_id.sql
+++ b/api/sql/thing_by_id.sql
@@ -19,6 +19,7 @@ full_thing AS (
     COALESCE(${table:name}.files, '{}') files,
     COALESCE(${table:name}.videos, '{}') videos,
     COALESCE(${table:name}.tags, '{}') tags,
+    COALESCE(${table:name}.links, '{}') links,
     localized_texts.body,
     localized_texts.title,
     authors_list.authors,

--- a/migrations/migration_026.sql
+++ b/migrations/migration_026.sql
@@ -1,0 +1,5 @@
+ALTER TABLE things
+  DROP COLUMN url;
+
+ALTER TABLE things
+  ADD COLUMN links TEXT[] DEFAULT '{}';

--- a/setup.sql
+++ b/setup.sql
@@ -277,3 +277,4 @@ CREATE TABLE bookmarks (
 \include 'migrations/migration_023.sql'
 \include 'migrations/migration_024.sql'
 \include 'migrations/migration_025.sql'
+\include 'migrations/migration_026.sql'

--- a/test/methods.js
+++ b/test/methods.js
@@ -252,8 +252,7 @@ describe("Methods", () => {
         .putJSON("/method/" + method1.id)
         .set("Authorization", "Bearer " + tokens.user_token)
         .send({ tags });
-      const res3 = await chai.getJSON("/method/" + method1.id).send({});
-      const method1_new = res3.body.data;
+      const method1_new = res2.body.data;
       method1_new.tags.should.deep.equal(tags);
     });
     it("Add method, then change links", async () => {

--- a/test/methods.js
+++ b/test/methods.js
@@ -21,7 +21,9 @@ async function addBasicMethod() {
       vidURL: "https://www.youtube.com/watch?v=ZPoqNeR3_UA&t=11050s",
       related_cases: [5, 6, 7, 8],
       related_methods: [148, 149, 150],
-      related_organizations: [202, 203, 204]
+      related_organizations: [202, 203, 204],
+      tags: ["OIDP2017", "Tag1", "Tag2"],
+      links: ["http://killsixbilliondemons.com/", "http://dresdencodak.com/"]
     });
 }
 
@@ -85,6 +87,13 @@ describe("Methods", () => {
       returnedMethod.related_cases.length.should.equal(4);
       returnedMethod.related_methods.length.should.equal(3);
       returnedMethod.related_organizations.length.should.equal(3);
+      returnedMethod.links.should.have.lengthOf(2);
+      returnedMethod.tags.should.have.lengthOf(3);
+      returnedMethod.links.should.deep.equal([
+        "http://killsixbilliondemons.com/",
+        "http://dresdencodak.com/"
+      ]);
+      returnedMethod.tags.should.deep.equal(["OIDP2017", "Tag1", "Tag2"]);
     });
   });
   describe("Get method with tags", () => {

--- a/test/methods.js
+++ b/test/methods.js
@@ -254,7 +254,18 @@ describe("Methods", () => {
         .send({ tags });
       const res3 = await chai.getJSON("/method/" + method1.id).send({});
       const method1_new = res3.body.data;
-      method1_new.tags.should.deep.equal(["foo", "bar"]);
+      method1_new.tags.should.deep.equal(tags);
+    });
+    it("Add method, then change links", async () => {
+      const res1 = await addBasicMethod();
+      const method1 = res1.body.object;
+      const links = ["https://xkcd.com/", "http://girlgeniusonline.com/"];
+      const res2 = await chai
+        .putJSON("/method/" + method1.id)
+        .set("Authorization", "Bearer " + tokens.user_token)
+        .send({ links });
+      const method1_new = res2.body.data;
+      method1_new.links.should.deep.equal(links);
     });
   });
 });


### PR DESCRIPTION
* `links` is now a list of strings on all main objects, like `tags`
* No backend enforcement of URL-ness is done currently.
* Supports `links`, `tags` for initial creation (quick submit)
* Cases also support `issue`, `specific_topic` in quick submit
* Organizations also support `issue` in quick submit

Fixes #132