### PR TITLE
135 search results

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -57,7 +57,7 @@ const singularLowerCase = name => name.slice(0, -1).toLowerCase();
 // like it says on the tin
 const filterFromReq = req => {
   const cat = singularLowerCase(req.query.selectedCategory || "Alls");
-  return cat === "all" ? "" : `AND things.type = '${cat}'`;
+  return cat === "all" ? "" : `AND type = '${cat}'`;
 };
 
 const queryFileFromReq = req => {
@@ -121,7 +121,9 @@ router.get("/", async function(req, res) {
       offset: offsetFromReq(req),
       userId: req.user ? req.user.user_id : null
     });
-    res.status(200).json({ OK: true, results: objList });
+    const total = objList.length ? objList[0].total : 0;
+    objList.forEach(obj => delete obj.total);
+    res.status(200).json({ OK: true, total: total, results: objList });
   } catch (error) {
     console.error("Error in search: ", error);
     console.trace(error);

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -121,9 +121,12 @@ router.get("/", async function(req, res) {
       offset: offsetFromReq(req),
       userId: req.user ? req.user.user_id : null
     });
-    const total = objList.length ? objList[0].total : 0;
+    const total = Number(objList.length ? objList[0].total || 0 : 0);
+    const pages = Math.ceil(total / RESPONSE_LIMIT);
     objList.forEach(obj => delete obj.total);
-    res.status(200).json({ OK: true, total: total, results: objList });
+    res
+      .status(200)
+      .json({ OK: true, total: total, pages: pages, results: objList });
   } catch (error) {
     console.error("Error in search: ", error);
     console.trace(error);

--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -147,6 +147,14 @@ function location(location) {
   return `(${name}, '', '', ${city}, ${province}, ${country}, '', ${lat}, ${long})::geolocation`;
 }
 
+// replace as.text, don't convert null to "null" because that's dumb
+function text(value) {
+  if (value === null) {
+    return value;
+  }
+  return pgp.as.text(value);
+}
+
 const as = Object.assign({}, pgp.as, {
   author,
   attachment,
@@ -155,7 +163,8 @@ const as = Object.assign({}, pgp.as, {
   videos,
   number,
   strings,
-  tags
+  tags,
+  text
 });
 
 const helpers = pgp.helpers;

--- a/api/sql/featured.sql
+++ b/api/sql/featured.sql
@@ -5,21 +5,29 @@
 -- limit (20 for now)
 -- userid (may be null)
 -- filter (only return results of *type*
-SELECT
-  id,
-  type,
-  featured,
-  title,
-  substring(body for 500) AS body,
-  to_json(COALESCE(location, '("","","","","","","","","")'::geolocation)) AS location,
-  to_json(COALESCE(lead_image, '("","",0)'::attachment)) AS lead_image,
-  updated_date,
-  bookmarked(type, id, ${userId})
-FROM things, localized_texts
-WHERE things.id = localized_texts.thingid AND
-      localized_texts.language = ${language}
-      ${filter:raw}
-ORDER BY featured DESC, updated_date DESC
+WITH all_featured  AS (
+  SELECT
+    id,
+    type,
+    featured,
+    title,
+    substring(body for 500) AS body,
+    to_json(COALESCE(location, '("","","","","","","","","")'::geolocation)) AS location,
+    to_json(COALESCE(lead_image, '("","",0)'::attachment)) AS lead_image,
+    updated_date,
+    bookmarked(type, id, ${userId})
+  FROM things, localized_texts
+  WHERE things.id = localized_texts.thingid AND
+        localized_texts.language = ${language}
+        ${filter:raw}
+  ORDER BY featured DESC, updated_date DESC
+),
+total_featured AS (
+  SELECT count(all_featured.id) AS total
+  FROM all_featured
+)
+SELECT all_featured.*, total_featured.total
+FROM all_featured, total_featured
 OFFSET ${offset}
 LIMIT ${limit}
 ;

--- a/api/sql/search.sql
+++ b/api/sql/search.sql
@@ -4,20 +4,34 @@
 -- offset (defaults to 1)
 -- limit (20 for now)
 -- userid (may be null)
+WITH all_selections AS (SELECT
+  id,
+  title,
+  substring(body for 500) AS body
+FROM search_index_${language:raw}
+WHERE document @@ plainto_tsquery('english', ${query})
+  ${filter:raw}
+ORDER BY ts_rank(search_index_${language:raw}.document, plainto_tsquery('english', ${query})) DESC
+),
+total_selections AS (
+  SELECT count(all_selections.id) AS total
+  FROM all_selections
+)
+
 SELECT
   things.id,
   things.type,
   things.featured,
-  title,
-  substring(body for 500) AS body,
+  all_selections.title,
+  all_selections.body,
   to_json(COALESCE(things.location, '("","","","","","","","","")'::geolocation)) AS location,
   to_json(COALESCE(things.lead_image, '("","",0)'::attachment)) AS lead_image,
   things.updated_date,
-  bookmarked(things.type, things.id, ${userId})
-FROM search_index_${language:raw}, things
-WHERE document @@ plainto_tsquery('english', ${query}) ${filter:raw} AND
-      search_index_${language:raw}.id = things.id
-ORDER BY ts_rank(search_index_${language:raw}.document, plainto_tsquery('english', ${query})) DESC
+  bookmarked(things.type, things.id, ${userId}),
+  total_selections.total
+FROM all_selections, total_selections, things
+WHERE all_selections.id = things.id AND
+  all_selections.id = things.id
 OFFSET ${offset}
 LIMIT ${limit}
 ;

--- a/migrations/migration_028.sql
+++ b/migrations/migration_028.sql
@@ -1,3 +1,10 @@
+-- Fix instances of "null" vs. null
+
+UPDATE cases SET specific_topic = NULL WHERE specific_topic = 'null';
+UPDATE cases SET issue = NULL WHERE issue = 'null';
+UPDATE organization SET issue = NULL WHERE issue = 'null';
+
+
  -- Modify Materialized view and index for English searches
 
 DROP MATERIALIZED VIEW search_index_en;
@@ -34,7 +41,7 @@ SELECT
     things.updated_date,
     setweight(to_tsvector('english'::regconfig, localized_texts.title), 'A') ||
     setweight(to_tsvector('english'::regconfig, localized_texts.body), 'A') ||
-    setweight(to_tsvector('english'::regconfig, alltags.tagstring), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(alltags.tagstring, '')), 'A') ||
     setweight(to_tsvector('english'::regconfig, allauthors.authorstring), 'A') ||
     setweight(to_tsvector('english'::regconfig, COALESCE((things.location).city, '')), 'A') ||
     setweight(to_tsvector('english'::regconfig, COALESCE((things.location).country, '')), 'A') AS document
@@ -42,7 +49,7 @@ SELECT
 		things
   JOIN localized_texts ON localized_texts.thingid = things.id
   JOIN allauthors ON allauthors.thingid = things.id
-  JOIN alltags ON alltags.thingid = things.id
+  LEFT JOIN alltags ON alltags.thingid = things.id
 	WHERE
 		localized_texts.language = 'en' -- this is the english search view
 ;

--- a/migrations/migration_028.sql
+++ b/migrations/migration_028.sql
@@ -1,0 +1,50 @@
+ -- Modify Materialized view and index for English searches
+
+DROP MATERIALIZED VIEW search_index_en;
+
+ CREATE MATERIALIZED VIEW search_index_en AS
+
+ WITH allauthors AS (
+   SELECT
+     things.id thingid,
+     string_agg(users.name, ' ') authorstring
+   FROM users, authors, things
+   WHERE
+    authors.user_id = users.id AND
+    authors.thingid = things.id
+   GROUP BY things.id
+),
+alltags as (
+  SELECT
+	thingid,
+	COALESCE(string_agg(tags, ' '), '') tagstring
+  FROM
+  	(SELECT things.id thingid, unnest(things.tags) tags FROM things) subtags
+  GROUP BY
+  	thingid
+)
+
+SELECT
+		things.id,
+    things.type,
+    things.location,
+    localized_texts.title,
+    localized_texts.body,
+    things.lead_image,
+    things.updated_date,
+    setweight(to_tsvector('english'::regconfig, localized_texts.title), 'A') ||
+    setweight(to_tsvector('english'::regconfig, localized_texts.body), 'A') ||
+    setweight(to_tsvector('english'::regconfig, alltags.tagstring), 'A') ||
+    setweight(to_tsvector('english'::regconfig, allauthors.authorstring), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE((things.location).city, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE((things.location).country, '')), 'A') AS document
+	FROM
+		things
+  JOIN localized_texts ON localized_texts.thingid = things.id
+  JOIN allauthors ON allauthors.thingid = things.id
+  JOIN alltags ON alltags.thingid = things.id
+	WHERE
+		localized_texts.language = 'en' -- this is the english search view
+;
+
+CREATE INDEX idx_fts_search_en ON search_index_en USING gin(document);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "postinstall": "./node_modules/apidoc/bin/apidoc -i api -o swagger",
     "deploy": "git push heroku",
     "coverage": "NODE_ENV=test istanbul cover _mocha -- -R spec && open coverage/lcov-report/index.html",
-    "test": "NODE_ENV=test mocha --timeout 10000",
+    "test": "NODE_ENV=test mocha --timeout 50000",
     "watch": "tape-watch --watch -1 test/**/*.js | faucet "
   }
 }

--- a/setup.sql
+++ b/setup.sql
@@ -279,3 +279,4 @@ CREATE TABLE bookmarks (
 \include 'migrations/migration_025.sql'
 \include 'migrations/migration_026.sql'
 \include 'migrations/migration_027.sql'
+\include 'migrations/migration_028.sql'

--- a/test/search.js
+++ b/test/search.js
@@ -36,14 +36,14 @@ describe("Search", () => {
       should.equal(Object.keys(res.body).length, 20);
     });
   });
-  describe.only("get organizations in Canada", () => {
+  describe("get organizations in Canada", () => {
     it("finds all Organizations with the term Canada", async () => {
       const res = await chai
         .getJSON("/search?query=Canada&selectedCategory=Organizations")
         .send({});
       res.should.have.status(200);
       res.body.OK.should.equal(true);
-      res.body.results.should.have.lengthOf(17);
+      res.body.results.should.have.lengthOf(20);
       res.body.results.forEach(obj => obj.type.should.equal("organization"));
     });
   });
@@ -54,16 +54,16 @@ describe("Search", () => {
         .send({});
       res.should.have.status(200);
       res.body.OK.should.equal(true);
-      res.body.results.should.have.lengthOf(3);
+      res.body.results.should.have.lengthOf(13);
       res.body.results[0].type.should.equal("case");
     });
   });
-  describe.skip("Test search with multi-word tags", () => {
+  describe("Test search with multi-word tags", () => {
     it("finds everything with the words animal welfare", async () => {
       const res = await chai.getJSON("/search?query=animal%20welfare").send({});
       res.should.have.status(200);
       res.body.OK.should.equal(true);
-      res.body.results.should.have.lengthOf(2);
+      res.body.results.should.have.lengthOf(6);
       // more testing
     });
   });

--- a/test/search.js
+++ b/test/search.js
@@ -36,7 +36,7 @@ describe("Search", () => {
       should.equal(Object.keys(res.body).length, 20);
     });
   });
-  describe.skip("get organizations in Canada", () => {
+  describe.only("get organizations in Canada", () => {
     it("finds all Organizations with the term Canada", async () => {
       const res = await chai
         .getJSON("/search?query=Canada&selectedCategory=Organizations")


### PR DESCRIPTION
Now indexing all objects for search, instead of only about 1/4 of them. Also:

* Returns `pages` and `total` in search results (but not map-view results) showing how many matches there are overall in raw numbers and pagination respectively.
* Fixes "null" -> null both for historic data and going forward

Fixes #84 
Fixes #135 
Fixes #141 

Requires migration 28