### PR TITLE
never return multiple users by email

### DIFF
--- a/api/helpers/user.js
+++ b/api/helpers/user.js
@@ -67,7 +67,7 @@ async function commonUserHandler(required, req, res, next) {
     }
     next();
   } catch (error) {
-    console.trace("Problem creating user", error);
+    console.trace("Problem creating user", JSON.stringify(error));
     return res.status(500).json({
       OK: false,
       error: error

--- a/api/sql/user_by_email.sql
+++ b/api/sql/user_by_email.sql
@@ -4,4 +4,6 @@ FROM
 	users
 WHERE
 	email = ${userEmail}
+LIMIT
+  1
 ;


### PR DESCRIPTION
Still need to eliminate duplicate users, but this will at least keep QuickSubmit from failing because we find multiple users by email.