### PR TITLE
handle more complex searchs across more fields

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -133,10 +133,11 @@ router.get("/", async function(req, res) {
       userId: req.user ? req.user.user_id : null
     });
     // These will be zero for resultType=map and that's OK
-    const total = Number(objList.length ? objList[0].total || 0 : 0);
+    const total = Number(results.length ? results[0].total || 0 : 0);
     const pages = Math.ceil(total / RESPONSE_LIMIT);
-    objList.forEach(obj => delete obj.total);
+    results.forEach(obj => delete obj.total);
     let OK = true;
+    log.error("here I am");
     return res
       .status(200)
       .json({ OK, total, pages, results, user_query, parsed_query });

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -2,6 +2,7 @@
 let express = require("express");
 let router = express.Router(); // eslint-disable-line new-cap
 let { db, sql, as } = require("../helpers/db");
+let { preparse_query } = require("../helpers/search");
 let log = require("winston");
 const { supportedTypes } = require("../helpers/things");
 
@@ -120,9 +121,11 @@ const offsetFromReq = req => {
 // One further item: need an alternative search which returns only map-level items and has no pagination
 
 router.get("/", async function(req, res) {
+  const user_query = req.query.query || "";
+  const parsed_query = preparse_query(user_query);
   try {
-    const objList = await db.any(queryFileFromReq(req), {
-      query: req.query.query,
+    const results = await db.any(queryFileFromReq(req), {
+      query: parsed_query,
       language: as.value(req.query.language || "en"),
       filter: filterFromReq(req),
       limit: RESPONSE_LIMIT,
@@ -133,13 +136,14 @@ router.get("/", async function(req, res) {
     const total = Number(objList.length ? objList[0].total || 0 : 0);
     const pages = Math.ceil(total / RESPONSE_LIMIT);
     objList.forEach(obj => delete obj.total);
+    let OK = true;
     return res
       .status(200)
-      .json({ OK: true, total: total, pages: pages, results: objList });
+      .json({ OK, total, pages, results, user_query, parsed_query });
   } catch (error) {
     console.error("Error in search: ", error);
     console.trace(error);
-    res.status(500).json({ error: error });
+    res.status(500).json({ error });
   }
 });
 

--- a/api/helpers/search.js
+++ b/api/helpers/search.js
@@ -1,0 +1,63 @@
+const is_whitespace = str => /^\s+$/.test(str);
+
+const is_word = str => /^[a-z]+$/.test(str);
+
+const pre_word_connector = (last_token, inside_quotes) => {
+  if (last_token === "WORD") {
+    if (inside_quotes) {
+      return "<->";
+    } else {
+      return "&";
+    }
+  } else {
+    return "";
+  }
+};
+
+const tokenize = function*(query, inside_quotes = false) {
+  let re = /".*?"|[a-z]+|<->|&|\||\!|\(|\)/g;
+  let last_token = null;
+  let tokenObj = null;
+  while ((tokenObj = re.exec(query)) !== null) {
+    let token = tokenObj[0];
+    if (token[0] === '"') {
+      yield pre_word_connector(last_token, inside_quotes);
+      for (t of tokenize(token.slice(1, -1), true)) {
+        yield t;
+      }
+      last_token = "WORD";
+    } else if (token === "and" || token === "&") {
+      last_token = "CONNECT";
+      yield "&";
+    } else if (token === "or" || token === "|") {
+      last_token = "CONNECT";
+      yield "|";
+    } else if (token === "not" || token === "!") {
+      last_token = "CONNECT";
+      yield "!";
+    } else if (token === "<->") {
+      last_token = "CONNECT";
+      yield token;
+    } else if (token === "(") {
+      yield pre_word_connector(last_token, inside_quotes);
+      last_token = "CONNECT";
+      yield token;
+    } else if (token === ")") {
+      last_token = "WORD";
+      yield token;
+    } else if (is_word(token)) {
+      yield pre_word_connector(last_token, inside_quotes);
+      last_token = "WORD";
+      yield token;
+    }
+  }
+};
+
+const preparse_query = function(userQuery) {
+  return [...tokenize(userQuery.toLowerCase())].join("");
+};
+
+module.exports = {
+  preparse_query,
+  tokenize
+};

--- a/api/helpers/search.js
+++ b/api/helpers/search.js
@@ -33,6 +33,9 @@ const tokenize = function*(query, inside_quotes = false) {
       last_token = "CONNECT";
       yield "|";
     } else if (token === "not" || token === "!") {
+      if (last_token === "WORD") {
+        yield "&"; // cannot have a bare NOT, needs a connector
+      }
       last_token = "CONNECT";
       yield "!";
     } else if (token === "<->") {

--- a/api/sql/search.sql
+++ b/api/sql/search.sql
@@ -9,9 +9,9 @@ WITH all_selections AS (SELECT
   title,
   substring(body for 500) AS body
 FROM search_index_${language:raw}
-WHERE document @@ plainto_tsquery('english', ${query})
+WHERE document @@ to_tsquery('english', ${query})
   ${filter:raw}
-ORDER BY ts_rank(search_index_${language:raw}.document, plainto_tsquery('english', ${query})) DESC
+ORDER BY ts_rank(search_index_${language:raw}.document, to_tsquery('english', ${query})) DESC
 ),
 total_selections AS (
   SELECT count(all_selections.id) AS total

--- a/api/sql/searchmap.sql
+++ b/api/sql/searchmap.sql
@@ -13,7 +13,7 @@ SELECT
   to_json(COALESCE(things.images, '{}')) AS images,
   to_json(COALESCE(things.videos, '{}')) AS videos
 FROM search_index_${language:raw}, things
-WHERE document @@ plainto_tsquery('english', ${query}) ${filter:raw} AND
+WHERE document @@ to_tsquery('english', ${query}) ${filter:raw} AND
       search_index_${language:raw}.id = things.id
-ORDER BY ts_rank(search_index_${language:raw}.document, plainto_tsquery('english', ${query})) DESC
+ORDER BY ts_rank(search_index_${language:raw}.document, to_tsquery('english', ${query})) DESC
 ;

--- a/migrations/migration_033.sql
+++ b/migrations/migration_033.sql
@@ -1,0 +1,122 @@
+ -- Modify Materialized view and index for English searches
+
+DROP MATERIALIZED VIEW search_index_en;
+
+ CREATE MATERIALIZED VIEW search_index_en AS
+
+ WITH allauthors AS (
+   SELECT
+     things.id thingid,
+     string_agg(users.name, ' ') authorstring
+   FROM users, authors, things
+   WHERE
+    authors.user_id = users.id AND
+    authors.thingid = things.id
+   GROUP BY things.id
+),
+alltags as (
+  SELECT
+	thingid,
+	COALESCE(string_agg(tags, ' '), '') tagstring
+  FROM
+  	(SELECT things.id thingid, unnest(things.tags) tags FROM things) subtags
+  GROUP BY
+  	thingid
+)
+
+SELECT
+		cases.id,
+    cases.type,
+    localized_texts.title,
+    localized_texts.body,
+    setweight(to_tsvector('english'::regconfig, localized_texts.title), 'A') ||
+    setweight(to_tsvector('english'::regconfig, localized_texts.body), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(alltags.tagstring, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, allauthors.authorstring), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE((cases.location).city, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE((cases.location).country, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.issue, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.communication_mode, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.communication_with_audience, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.decision_method, '')), 'A') ||
+    -- can't default enums to empty strings
+    -- setweight(to_tsvector('english'::regconfig, cases.facetoface_online_or_both), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.facilitated, '')), 'A') ||
+    -- ibid
+    -- setweight(to_tsvector('english'::regconfig, COALESCE(cases.voting, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.targeted_participant_demographic, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.kind_of_influence, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.targeted_participants_public_role, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.targeted_audience, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.participant_selection, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.specific_topic, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.staff_type, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.type_of_funding_entity, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.typical_implementing_entity, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.typical_sponsoring_entity, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(cases.who_else_supported_the_initiative, '')), 'A')
+    AS document
+	FROM
+		cases
+  JOIN localized_texts ON localized_texts.thingid = cases.id
+  JOIN allauthors ON allauthors.thingid = cases.id
+  LEFT JOIN alltags ON alltags.thingid = cases.id
+	WHERE
+    cases.hidden = false AND
+		localized_texts.language = 'en' -- this is the english search view
+UNION
+SELECT
+		methods.id,
+    methods.type,
+    localized_texts.title,
+    localized_texts.body,
+    setweight(to_tsvector('english'::regconfig, localized_texts.title), 'A') ||
+    setweight(to_tsvector('english'::regconfig, localized_texts.body), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(alltags.tagstring, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, allauthors.authorstring), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.best_for, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.communication_mode, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.decision_method, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.governance_contribution, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.issue_interdependency, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.issue_polarization, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.issue_technical_complexity, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.kind_of_influence, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.method_of_interaction, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.public_interaction_method, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.typical_funding_source, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(methods.typical_implementing_entity, '')), 'A')
+    AS document
+	FROM
+		methods
+  JOIN localized_texts ON localized_texts.thingid = methods.id
+  JOIN allauthors ON allauthors.thingid = methods.id
+  LEFT JOIN alltags ON alltags.thingid = methods.id
+	WHERE
+    methods.hidden = false AND
+		localized_texts.language = 'en' -- this is the english search view
+UNION
+SELECT
+		organizations.id,
+    organizations.type,
+    localized_texts.title,
+    localized_texts.body,
+    setweight(to_tsvector('english'::regconfig, localized_texts.title), 'A') ||
+    setweight(to_tsvector('english'::regconfig, localized_texts.body), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(alltags.tagstring, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, allauthors.authorstring), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE((organizations.location).city, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE((organizations.location).country, '')), 'A') ||
+    setweight(to_tsvector('english'::regconfig, COALESCE(organizations.executive_director, '')), 'A')
+    AS document
+	FROM
+		organizations
+  JOIN localized_texts ON localized_texts.thingid = organizations.id
+  JOIN allauthors ON allauthors.thingid = organizations.id
+  LEFT JOIN alltags ON alltags.thingid = organizations.id
+	WHERE
+    organizations.hidden = false AND
+		localized_texts.language = 'en' -- this is the english search view
+;
+
+CREATE INDEX idx_fts_search_en ON search_index_en USING gin(document);

--- a/setup.sql
+++ b/setup.sql
@@ -284,3 +284,4 @@ CREATE TABLE bookmarks (
 \include 'migrations/migration_030.sql'
 \include 'migrations/migration_031.sql'
 \include 'migrations/migration_032.sql'
+\include 'migrations/migration_033.sql'

--- a/test/search.js
+++ b/test/search.js
@@ -18,7 +18,7 @@ describe("Search", () => {
       should.equal(Object.keys(res.body).length, 20);
     });
   });
-  describe.only("confirm query tokenizing", () => {
+  describe("confirm query tokenizing", () => {
     let { tokenize } = require("../api/helpers/search");
     it("simple and", () => {
       [...tokenize("first and second")].should.deep.equal([
@@ -42,6 +42,7 @@ describe("Search", () => {
       [...tokenize("first not second")].should.deep.equal([
         "",
         "first",
+        "&",
         "!",
         "",
         "second"
@@ -139,7 +140,7 @@ describe("Search", () => {
       ]);
     });
   });
-  describe.only("confirm query parsing", () => {
+  describe("confirm query parsing", () => {
     let { preparse_query } = require("../api/helpers/search");
     it("simple and", () => {
       preparse_query("first and second").should.equal("first&second");
@@ -148,7 +149,7 @@ describe("Search", () => {
       preparse_query("first or second").should.equal("first|second");
     });
     it("simple not", () => {
-      preparse_query("first not second").should.equal("first!second");
+      preparse_query("first not second").should.equal("first&!second");
     });
     it("parentheses", () => {
       preparse_query("first or (second and third)").should.equal(

--- a/test/search.js
+++ b/test/search.js
@@ -38,6 +38,15 @@ describe("Search", () => {
         "second"
       ]);
     });
+    it("simple not", () => {
+      [...tokenize("first not second")].should.deep.equal([
+        "",
+        "first",
+        "!",
+        "",
+        "second"
+      ]);
+    });
     it("parentheses", () => {
       [...tokenize("first or (second and third)")].should.deep.equal([
         "",
@@ -137,6 +146,9 @@ describe("Search", () => {
     });
     it("simple or", () => {
       preparse_query("first or second").should.equal("first|second");
+    });
+    it("simple not", () => {
+      preparse_query("first not second").should.equal("first!second");
     });
     it("parentheses", () => {
       preparse_query("first or (second and third)").should.equal(


### PR DESCRIPTION
Fixes https://github.com/participedia/frontend/issues/601

With this PR you can now search across nearly every text field of cases, methods, and organizations in the full text search, with the exceptions of "Face-to-face, online, or both" and "voting" because of a limitation with how we store those. I can address those later with another migration but wanted to handle the 99% first.

You can also do more complex queries now. Supported options include:

AND: `bicycle and rally` (this is the default, so the same as `bicycle rally`) will return items which match both words
OR: `bicycle or rally` will match items with either or both words
NOT: `bicycle not rally` will match items which contain bicycle, but only if they do not also contain rally
QUOTES: `"womens rights"` will return items that have "womens" followed by "rights"
PARENTHESES: `(bicycle or rally) and ("womens rights" and UK)` will will group logical operations inside the parentheses as a group before applying the operators joining groups

All of these operations can be combined.

Searches are not cases sensitive. Stop words (simple words too common to search on like I, they, we, should, ...) are ignored. Words are stemmed, so `women` and `womens` and `women's` will all match the same.
