### PR TITLE
return organization name

### DIFF
--- a/api/sql/user_by_id.sql
+++ b/api/sql/user_by_id.sql
@@ -62,12 +62,46 @@ authored_organizations AS (
   FROM authored_things
   WHERE (thing).type = 'organization'
   GROUP BY author
+),
+user_organizations AS (
+  SELECT
+    users.organization id,
+    texts.title title
+  FROM
+    users,
+    texts
+  WHERE
+    users.id = ${userId} AND
+    users.organization IS NOT NULL AND
+    texts.thingid = users.organization
+  UNION ALL
+  SELECT
+    NULL id,
+    '' title
+  WHERE NOT EXISTS ( SELECT 1 FROM users WHERE users.id = ${userId} AND users.organization IS NOT NULL)
 )
 
 SELECT row_to_json(user_row) as user
 FROM (
 SELECT
-	users.*,
+	users.id,
+  users.name,
+  users.email,
+  users.language,
+  users.language_1,
+  users.accepted_date,
+  users.last_access_date,
+  users.login,
+  users.auth0_user_id,
+  users.join_date,
+  users.picture_url,
+  users.affiliation,
+  users.title,
+  users.bio,
+  users.location,
+  users.department,
+  users.website,
+  (user_organizations.id, user_organizations.title)::object_title as organization,
   COALESCE(users.location, ('','','','','','','','','')::geolocation) AS location,
   'user' as type,
 	COALESCE(authored_cases.cases, '{}') cases,
@@ -75,6 +109,7 @@ SELECT
 	COALESCE(authored_organizations.organizations, '{}') organizations,
   COALESCE(ARRAY(SELECT ROW(id, title, type, images, post_date, updated_date)::object_short FROM user_bookmarks), '{}') bookmarks
 FROM
+  user_organizations,
   users
   LEFT JOIN authored_cases ON users.id = authored_cases.author
   LEFT JOIN authored_methods ON users.id = authored_methods.author

--- a/test/users.js
+++ b/test/users.js
@@ -59,7 +59,7 @@ describe("Users", () => {
       const website = origUser.website
         ? ""
         : "https://pirateparty.ca/platforms/";
-      const organization = origUser.organization === 204 ? 209 : 204;
+      const organization = origUser.organization.id === 204 ? 209 : 204;
       await chai
         .postJSON("/user/")
         .set("Authorization", "Bearer " + tokens.user_token)
@@ -78,7 +78,7 @@ describe("Users", () => {
       const newUser = res2.body.data;
       newUser.department.should.equal(department);
       newUser.website.should.equal(website);
-      newUser.organization.should.equal(organization);
+      newUser.organization.id.should.equal(organization);
     });
   });
 });


### PR DESCRIPTION
Fixes #231 

Instead of returning the id of an organization, this will return a structure of `{name: , id: }`. If there is no associated id the structure will still be there, but will be `{name: "", id: null}`.

@andreadelrio Will this work for you. You will need the name for display, but the id to build a link.
