### PR TITLE
Return all when all requested

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -26,7 +26,9 @@ router.get("/getAllForType", async function getAllForType(req, res) {
     let page = Math.max(parseInt(req.query.page || 1), 1);
     let offset = 0;
     let response_limit = Number.MAX_SAFE_INTEGER;
-    if (
+    if (!req.query.response_limit) {
+      // do nothing, return everything
+    } else if (
       req.query.response_limit &&
       req.query.response_limit.toLowerCase() === "none"
     ) {
@@ -42,7 +44,7 @@ router.get("/getAllForType", async function getAllForType(req, res) {
     }
     const titlelist = await db.any(TITLES_FOR_THINGS, {
       language: as.value(req.query.language || "en"),
-      limit: RESPONSE_LIMIT,
+      limit: response_limit,
       offset: offset,
       type: objType
     });

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -25,7 +25,7 @@ router.get("/getAllForType", async function getAllForType(req, res) {
     let objType = req.query.objType.toLowerCase();
     let page = Math.max(parseInt(req.query.page || 1), 1);
     let offset = 0;
-    let response_limit = RESPONSE_LIMIT;
+    let response_limit = Number.MAX_SAFE_INTEGER;
     if (
       req.query.response_limit &&
       req.query.response_limit.toLowerCase() === "none"


### PR DESCRIPTION
Was forcing all requests to be limited to 20 results in getAll* calls. Fixed that.