### PR TITLE
Partial fix for frontend #775

### DIFF
--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -339,7 +339,6 @@ function getEditXById(type) {
               "images",
               "videos",
               "files",
-              "participants_interactions",
               "if_voting",
               "evaluation_reports",
               "evaluation_links"
@@ -363,6 +362,7 @@ function getEditXById(type) {
               "learning_resources",
               "organizer_types",
               "purposes",
+              "participants_interactions",
               "targeted_participants"
             ].includes(key)
           ) {


### PR DESCRIPTION
We had one field we were handling as the wrong type vs. what we were getting from the frontend.

Necessary but not sufficient for fixing frontend 775.

Unfortunately, there is no easy fix for the data. We just have to manually fix these.