### PR TITLE
switched from list of authors to creator/last_updated_by

### DIFF
--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -315,7 +315,14 @@ function getEditXById(type) {
             isTextUpdated = true;
             // If any of the fields of thing itself have changed, update record in appropriate table
           } else if (
-            ["id", "post_date", "updated_date", "authors"].includes(key)
+            [
+              "id",
+              "post_date",
+              "updated_date",
+              "authors",
+              "creator",
+              "last_updated_by"
+            ].includes(key)
           ) {
             log.warn(
               "Trying to update a field users shouldn't update: %s",

--- a/api/sql/thing_by_id.sql
+++ b/api/sql/thing_by_id.sql
@@ -1,29 +1,4 @@
-WITH a2 AS (
-    SELECT DISTINCT ON (authors.user_id)
-      authors.user_id,
-      authors.timestamp,
-      users.name
-    FROM
-      authors,
-      users
-    WHERE
-      authors.user_id = users.id AND
-      authors.thingid = ${thingid}
-    ORDER BY
-      authors.user_id,
-      authors.timestamp
-),
- authors_list AS (
-  SELECT
-    array_agg((
-      a2.user_id,
-      a2.timestamp,
-      a2.name
-    )::author) authors
-  FROM
-    a2
-),
-full_thing AS (
+WITH full_thing AS (
   SELECT
     ${table:name}.*,
     COALESCE(images, '{}') AS images,
@@ -34,14 +9,14 @@ full_thing AS (
     texts.body,
     texts.title,
     texts.description,
-    authors_list.authors,
+    first_author(${thingid}) AS creator,
+    last_author(${thingid}) AS last_updated_by,
     get_location(${thingid}) AS location,
     ${case_only:raw}
     bookmarked(${table:name}.type, ${thingid}, ${userId})
 FROM
     ${table:name},
-    get_localized_texts(${thingid}, ${lang}) AS texts,
-    authors_list
+    get_localized_texts(${thingid}, ${lang}) AS texts
 WHERE
     ${table:name}.id = ${thingid}
 )

--- a/migrations/functions.sql
+++ b/migrations/functions.sql
@@ -162,3 +162,47 @@ SELECT
 FROM
     a2
 $_$;
+
+---
+--- Name: first_author(thingid); Type: FUNCTION: Schema: public; Owner: -
+---
+
+CREATE OR REPLACE FUNCTION first_author(thingid integer) RETURNS author
+  LANGUAGE sql STABLE
+  AS $_$
+  SELECT
+    authors.user_id,
+    authors.timestamp,
+    users.name
+  FROM
+    authors,
+    users
+  WHERE
+    authors.user_id = users.id AND
+    authors.thingid = $1
+  ORDER BY
+    authors.timestamp ASC
+  LIMIT 1
+$_$;
+
+---
+--- Name: last_author(thingid); Type: FUNCTION: Schema: public; Owner: -
+---
+
+CREATE OR REPLACE FUNCTION last_author(thingid integer) RETURNS author
+  LANGUAGE sql STABLE
+  AS $_$
+  SELECT
+    authors.user_id,
+    authors.timestamp,
+    users.name
+  FROM
+    authors,
+    users
+  WHERE
+    authors.user_id = users.id AND
+    authors.thingid = $1
+  ORDER BY
+    authors.timestamp DESC
+  LIMIT 1
+$_$;

--- a/test/cases.js
+++ b/test/cases.js
@@ -138,7 +138,6 @@ describe("Cases", () => {
       const updatedCase3 = res4.body.data;
       updatedCase3.title.should.equal("Third Title");
       updatedCase3.body.should.equal("Third Body");
-      updatedCase3.authors.length.should.equal(updatedCase2.authors.length);
     });
 
     it("Add case, then modify some fields", async () => {

--- a/test/methods.js
+++ b/test/methods.js
@@ -100,7 +100,6 @@ describe("Methods", () => {
       const updatedMethod3 = res4.body.data;
       updatedMethod3.title.should.equal("Third Title");
       updatedMethod3.body.should.equal("Third Body");
-      updatedMethod3.authors.length.should.equal(updatedMethod2.authors.length);
     });
     it("Add method, then modify lead image", async () => {
       const res1 = await addBasicMethod();

--- a/test/organizations.js
+++ b/test/organizations.js
@@ -111,9 +111,6 @@ describe("Organizations", () => {
       const updatedOrganization3 = res4.body.data;
       updatedOrganization3.title.should.equal("Third Title");
       updatedOrganization3.body.should.equal("Third Body");
-      updatedOrganization3.authors.length.should.equal(
-        updatedOrganization2.authors.length
-      );
     });
     it("Add organization, then modify lead image", async () => {
       const res1 = await addBasicOrganization();


### PR DESCRIPTION
We may need to bring the authors list back for versioning, but in most cases now we never use it, so switched to simpler creator / last_updated_by pair of values. Requires changes in the frontend at the same time.

Fixes #254