### PR TITLE
add authors list to case edit when the user is an admin

### DIFF
--- a/api/sql/case_edit_by_id.sql
+++ b/api/sql/case_edit_by_id.sql
@@ -69,6 +69,7 @@ SELECT
   published,
   updated_date,
   featured,
+   get_user_names(${userid})  as authors,
   hidden
 FROM
   cases,

--- a/migrations/migration_030.sql
+++ b/migrations/migration_030.sql
@@ -1,0 +1,21 @@
+--
+-- Name: object_title; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE user_name AS (
+	id integer,
+	name text
+);
+
+CREATE OR REPLACE FUNCTION get_user_names(userid integer) RETURNS user_name[]
+  LANGUAGE sql STABLE
+  AS $_$
+  SELECT
+    CASE
+      WHEN (select isadmin from users where id = userid) THEN
+        array_agg((id, name)::user_name)
+      ELSE
+        '{}'
+      END
+    FROM users;
+$_$;


### PR DESCRIPTION
Adds list of {id, name} for all system users to case data as `authors` if the current user is an admin. If the current user is not an admin, returns an empty list as `authors`.

Requires `npm run migratelocal 30`

Requested as part of #407 