### PR TITLE
Localization for static pages

### DIFF
--- a/api/helpers/data/about-data.js
+++ b/api/helpers/data/about-data.js
@@ -1,9 +1,10 @@
 const partners = [
   {
-    "title": "Principal Investigator",
+    "titleKey": "Principal Investigator",
     "members": [
       {
-        "name": "Mark E. Warren, Project Director and Co-Founder",
+        "name": "Mark E. Warren",
+        "titleKey": "Project Director and Co-Founder",
         "descriptors": [
           "Department of Political Science / Centre for the Study of Democratic Institutions",
           "University of British Columbia"
@@ -12,7 +13,7 @@ const partners = [
     ]
   },
   {
-    "title": "Co-investigators",
+    "titleKey": "Co-investigators",
     "members": [
       {
         "name": "Julia Abelson",
@@ -244,7 +245,7 @@ const partners = [
     ]
   },
   {
-    "title": "Collaborators",
+    "titleKey": "Collaborators",
     "members": [
       {
         "name": "André Bächtiger",
@@ -380,7 +381,6 @@ const partners = [
       },
       {
         "name": "Alexandra Samuel",
-        "descriptors": []
       },
       {
         "name": "Eleonora Schettini Cunha",
@@ -427,7 +427,7 @@ const partners = [
     ]
   },
   {
-    "title": "Organizations",
+    "titleKey": "Organizations",
     "members": [
       {
         "name": "University of British Columbia",
@@ -437,11 +437,11 @@ const partners = [
       },
       {
         "name": "Coady International Institute",
-        "descriptors": []
+
       },
       {
         "name": "Deliberative Democracy Consortium",
-        "descriptors": []
+
       },
       {
         "name": "Emily Carr University of Art + Design",
@@ -631,50 +631,56 @@ const partners = [
 
 const committees = [
   {
-    "title": "Executive Committee",
-    "description": null,
+    "titleKey": "Executive Committee",
     "members": [
       {
-        "name": "Marco Adria, Chair, Communication & Knowledge Mobilization Committee",
+        "name": "Marco Adria",
+        "titleKey": "Chair, Communication & Knowledge Mobilization Committee",
         "descriptors": [
           "Centre for Public Involvement",
           "University of Alberta"
         ]
       },
       {
-        "name": "Amber Frid-Jimenez, Participedia Design Lead and Chair, Design & Technology Committee",
+        "name": "Amber Frid-Jimenez",
+        "titleKey": "Participedia Design Lead and Chair, Design & Technology Committee",
         "descriptors": [
           "Faculty of Design + Dynamic Media and Director, Studio for Extensive Aesthetics",
           "Emily Carr University of Art + Design"
         ]
       },
       {
-        "name": "Archon Fung, Co-Founder",
+        "name": "Archon Fung",
+        "titleKey": "Co-Founder",
         "descriptors": [
           "Ash Center for Democratic Governance and Innovation",
           "Harvard University"
         ]
       },
       {
-        "name": "Patrick L. Scully, (member ex officio), Managing Director",
-        "descriptors": []
+        "name": "Patrick L. Scully",
+        "titleKey": "(member ex officio), Managing Director",
+
       },
       {
-        "name": "Graham Smith, Chair, Research Design Committee",
+        "name": "Graham Smith",
+        "titleKey": "Chair, Research Design Committee",
         "descriptors": [
           "Centre for the Study of Democracy",
           "University of Westminster"
         ]
       },
       {
-        "name": "Bettina Von Lieres, Chair, Teaching, Training and Mentoring Committee",
+        "name": "Bettina Von Lieres",
+        "titleKey": "Chair, Teaching, Training and Mentoring Committee",
         "descriptors": [
           "Centre for Critical Development Studies",
           "University of Toronto-Scarborough"
         ]
       },
       {
-        "name": "Mark E. Warren, Project Director and Co-Founder",
+        "name": "Mark E. Warren",
+        "titleKey": "Project Director and Co-Founder",
         "descriptors": [
           "Department of Political Science / Centre for the Study of Democratic Institutions",
           "University of British Columbia"
@@ -683,89 +689,100 @@ const committees = [
     ]
   },
   {
-    "title": "Design & Technology Committee",
-    "description": "The Design & Technology Committee is responsible for the design and maintenance of the Participedia website.",
+    "titleKey": "Design & Technology Committee",
+    "descriptionKey": "The Design & Technology Committee is responsible for the design and maintenance of the Participedia website.",
     "members": [
       {
-        "name": "David Ascher, Technical Lead",
-        "descriptors": []
+        "name": "David Ascher",
+        "titleKey": "Technical Lead",
       },
       {
-        "name": "Jesi Carson, Design & Communities Coordinator",
+        "name": "Jesi Carson",
+        "titleKey": "Design & Communities Coordinator",
         "descriptors": [
           "Studio for Extensive Aesthetics",
           "Emily Carr University of Art + Design"
         ]
       },
       {
-        "name": "Andrea Del Rio, Developer",
+        "name": "Andrea Del Rio",
+        "titleKey": "Developer",
         "descriptors": [
           "Centre for Digital Media"
         ]
       },
       {
-        "name": "Dethe Elza, Developer",
-        "descriptors": []
+        "name": "Dethe Elza",
+        "titleKey": "Developer",
       },
       {
-        "name": "Amber Frid-Jimenez, Committee Chair, Design Lead",
+        "name": "Amber Frid-Jimenez",
+        "titleKey": "Committee Chair, Design Lead",
         "descriptors": [
           "Faculty of Design + Dynamic Media and Director, Studio for Extensive Aesthetics",
           "Emily Carr University of Art + Design"
         ]
       },
       {
-        "name": "Sam Jiang, Graphic Designer & Developer",
-        "descriptors": []
+        "name": "Sam Jiang",
+        "titleKey": "Graphic Designer & Developer",
+
       }
     ]
   },
   {
-    "title": "Communications & Knowledge Mobilization Committee",
-    "description": "The Communication and Knowledge Mobilization Committee is responsible for advising the Executive Committee on how communication with research partners can be planned, carried out, and refined. The CKM committee also advises on optimal communication with the Participedia user community, including supporting the development of content for the website, newsletter, and social media channels.",
+    "titleKey": "Communications & Knowledge Mobilization Committee",
+    "descriptionKey": "The Communication and Knowledge Mobilization Committee is responsible for advising the Executive Committee on how communication with research partners can be planned, carried out, and refined. The CKM committee also advises on optimal communication with the Participedia user community, including supporting the development of content for the website, newsletter, and social media channels.",
     "members": [
       {
-        "name": "Marco Adria, Chair, Communication & Knowledge Mobilization Committee",
+        "name": "Marco Adria",
+        "titleKey": "Chair, Communication & Knowledge Mobilization Committee",
         "descriptors": [
           "Centre for Public Involvement",
           "University of Alberta"
         ]
       },
       {
-        "name": "Jesi Carson, Design & Communities Coordinator",
+        "name": "Jesi Carson",
+        "titleKey": "Design & Communities Coordinator",
         "descriptors": [
           "Studio for Extensive Aesthetics",
           "Emily Carr University of Art + Design"
         ]
       },
       {
-        "name": "Sandy Heierbacher, Co-investigator",
+        "name": "Sandy Heierbacher",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "National Coalition for Dialogue and Deliberation"
         ]
       },
       {
-        "name": "Matt Leighninger, Co-investigator",
+        "name": "Matt Leighninger",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "Yankelovich Center for Public Judgment",
           "Public Agenda"
         ]
       },
       {
-        "name": "Paolo Spada, Collaborator",
+        "name": "Paolo Spada",
+        "titleKey": "Collaborator",
         "descriptors": [
           "University of Southampton"
         ]
       },
       {
-        "name": "Secchi Michelangelo, Research Assistant",
+        "name": "Secchi Michelangelo",
+        "titleKey": "Research Assistant",
         "descriptors": [
           "Center for Social Studies",
           "University of Coimbra"
         ]
       },
       {
-        "name": "Scott Fletcher, Research Assistant",
+        "name": "Scott Fletcher",
+        "titleKey": "Research Assistant",
         "descriptors": [
           "Department of Political Science / Centre for the Study of Democratic Institutions",
           "University of British Columbia"
@@ -774,46 +791,52 @@ const committees = [
     ]
   },
   {
-    "title": "Teaching Training & Mentoring Committee",
-    "description": "The Teaching Training and Mentoring Committee is responsible for developing outputs and implement actions for the integration of Participedia materials into pedagogy, teaching, student involvement and the training of practitioners and public officials.",
+    "titleKey": "Teaching Training & Mentoring Committee",
+    "descriptionKey": "The Teaching Training and Mentoring Committee is responsible for developing outputs and implement actions for the integration of Participedia materials into pedagogy, teaching, student involvement and the training of practitioners and public officials.",
     "members": [
       {
-        "name": "Joanna Ashworth, Co-investigator",
+        "name": "Joanna Ashworth",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "Centre for Sustainable Development",
           "Simon Fraser University"
         ]
       },
       {
-        "name": "Bonny Ibhawoh, Co-investigator",
+        "name": "Bonny Ibhawoh",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "Department of History",
           "McMaster University"
         ]
       },
       {
-        "name": "Katie Knobloch, Collaborator",
+        "name": "Katie Knobloch",
+        "titleKey": "Collaborator",
         "descriptors": [
           "Communication Studies",
           "Colorado State University"
         ]
       },
       {
-        "name": "Julien Landry, Collaborator",
+        "name": "Julien Landry",
+        "titleKey": "Collaborator",
         "descriptors": [
           "Coady International Institute",
           "St Francis Xavier University"
         ]
       },
       {
-        "name": "Marjorie Correa Marona, Collaborator",
+        "name": "Marjorie Correa Marona",
+        "titleKey": "Collaborator",
         "descriptors": [
           "Department of Political Science",
           "Universidade Federal de Minas Gerais"
         ]
       },
       {
-        "name": "Françoise Montambeaul, Co-investigator",
+        "name": "Françoise Montambeaul",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "Centre d'études et de recherches internationals (CÉRIUM)",
           "Centre for International Studies",
@@ -821,14 +844,16 @@ const committees = [
         ]
       },
       {
-        "name": "Tina Nabatchi, Co-investigator",
+        "name": "Tina Nabatchi",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "Program for the Advancement of Research on Conflict and Collaboration (PARCC)",
           "Maxwell School, Syracuse University"
         ]
       },
       {
-        "name": "Laurence Piper, Co-investigator",
+        "name": "Laurence Piper",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "Department of Political Science",
           "University of the Western Cape"
@@ -856,14 +881,16 @@ const committees = [
         ]
       },
       {
-        "name": "Bettina von Lieres, Co-investigator",
+        "name": "Bettina von Lieres",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "Centre for Critical Development Studies",
           "University of Toronto-Scarborough"
         ]
       },
       {
-        "name": "Ethan Way, Research Assistant",
+        "name": "Ethan Way",
+        "titleKey": "Research Assistant",
         "descriptors": [
           "University of Toronto-Scarborough"
         ]
@@ -871,11 +898,12 @@ const committees = [
     ]
   },
   {
-    "title": "Research Design Committee",
-    "description": "The Research Design Committee is responsible for setting the strategic direction of PPedia’s research agenda.",
+    "titleKey": "Research Design Committee",
+    "descriptionKey": "The Research Design Committee is responsible for setting the strategic direction of PPedia’s research agenda.",
     "members": [
       {
-        "name": "Leonardo Avritzer, Co-investigator",
+        "name": "Leonardo Avritzer",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "Federal University of Minas Gerais"
         ]
@@ -887,13 +915,15 @@ const committees = [
         ]
       },
       {
-        "name": "Matt Leighninger, Collaborator",
+        "name": "Matt Leighninger",
+        "titleKey": "Collaborator",
         "descriptors": [
           "Deliberative Democracy Consortium / Public Agenda"
         ]
       },
       {
-        "name": "Peter Loewen, Co-investigator",
+        "name": "Peter Loewen",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "University of Toronto"
         ]
@@ -911,19 +941,22 @@ const committees = [
         ]
       },
       {
-        "name": "Lucy Parry, Research Assistant",
+        "name": "Lucy Parry",
+        "titleKey": "Research Assistant",
         "descriptors": [
           "University of Canberra"
         ]
       },
       {
-        "name": "Matthew Ryan, Collaborator",
+        "name": "Matthew Ryan",
+        "titleKey": "Collaborator",
         "descriptors": [
           "University of Southampton"
         ]
       },
       {
-        "name": "Graham Smith, Co-investigator",
+        "name": "Graham Smith",
+        "titleKey": "Co-investigator",
         "descriptors": [
           "University of Westminster"
         ]
@@ -935,7 +968,8 @@ const committees = [
         ]
       },
       {
-        "name": "Mark E. Warren, Project Director and Co-Founder",
+        "name": "Mark E. Warren",
+        titleKey: "Project Director and Co-Founder",
         "descriptors": [
           "Department of Political Science / Centre for the Study of Democratic Institutions",
           "University of British Columbia"
@@ -945,7 +979,47 @@ const committees = [
   }
 ];
 
+const staff = {
+  "titleKey": "Staff",
+  "members": [
+    {
+      "name": "David Ascher",
+      "titleKey": "Technical Lead, Design & Technology Committee",
+    },
+    {
+      "name": "Jesi Carson",
+      "titleKey": "Design & Communities Coordinator",
+      "descriptors": [
+        "Emily Carr University of Art + Design",
+      ]
+    },
+    {
+      "name": "Rebecca Monnerat",
+      "titleKey": "Project Manager",
+      "descriptors": [
+        "University of British Columbia",
+      ]
+    },
+    {
+      "name": "Patrick L. Scully",
+      "titleKey": "(member ex officio), Managing Director",
+      "descriptors": [
+        "University of British Columbia",
+      ]
+    },
+    {
+      "name": "Mark E. Warren",
+      "titleKey": "Project Director and Co-Founder",
+      "descriptors": [
+        "Department of Political Science / Centre for the Study of Democratic Institutions",
+        "University of British Columbia",
+      ]
+    }
+  ]
+};
+
 module.exports = {
   partners: partners,
   committees: committees,
+  staff: staff,
 };

--- a/api/helpers/data/content-types-data.js
+++ b/api/helpers/data/content-types-data.js
@@ -12,11 +12,11 @@ module.exports = [
   {
     slug: "organizations",
     titleKey: "content_types.organization",
-    description: "content_types.organization.description"
+    descriptionKey: "content_types.organization.description"
   },
   {
     slug: "tools-techniques",
-    title: "content_types.tools-techniques",
-    description: "content_types.tools-techniques.description"
+    titleKey: "content_types.tools-techniques",
+    descriptionKey: "content_types.tools-techniques.description"
   },
 ];

--- a/api/helpers/data/content-types-data.js
+++ b/api/helpers/data/content-types-data.js
@@ -1,0 +1,22 @@
+module.exports = [
+  {
+    slug: "cases",
+    titleKey: "content_types.case",
+    descriptionKey: "content_types.case.description",
+  },
+  {
+    slug: "methods",
+    titleKey: "content_types.method",
+    descriptionKey: "content_types.method.description",
+  },
+  {
+    slug: "organizations",
+    titleKey: "content_types.organization",
+    description: "content_types.organization.description"
+  },
+  {
+    slug: "tools-techniques",
+    title: "content_types.tools-techniques",
+    description: "content_types.tools-techniques.description"
+  },
+];

--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -21,7 +21,9 @@ function staticTextValue(staticText, key, type = null) {
     newKey = key;
   }
 
-  if (staticText.labels) {
+  if (!staticText) {
+    return newKey;
+  } else if (staticText.labels) {
     return staticText.labels[newKey] || newKey;
   } else {
     // this makes the static keys work on the reader view for now
@@ -73,6 +75,7 @@ module.exports = {
     staticTextValue(staticText, name, "placeholder"),
 
   staticText: (staticText, key) => staticTextValue(staticText, key),
+  t: (staticText, key) => staticTextValue(staticText, key), // duplicate short function name
 
   getArticleOptions: (staticText, name) => {
     // has_components and is_component_of fields use the cases options
@@ -373,6 +376,10 @@ module.exports = {
 
   getCommitteesData() {
     return aboutData.committees;
+  },
+
+  getStaffData() {
+    return aboutData.members;
   },
 
   getContentTypeData() {

--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -1,6 +1,7 @@
 const moment = require("moment");
 const faqContent = require("./faq-content.js");
 const aboutData = require("./data/about-data.js");
+const contentTypesData = require("./data/content-types-data.js");
 const socialTagsTemplate = require("./social-tags-template.js");
 
 function mapIdTitleToKeyValue(options) {
@@ -383,28 +384,7 @@ module.exports = {
   },
 
   getContentTypeData() {
-    return [
-      {
-        slug: "cases",
-        title: "Case",
-        description: "Cases are specific events and instances of participatory politics and governance of all shapes and sizes. Cases can be contemporary or historical, completed, or ongoing."
-      },
-      {
-        slug: "methods",
-        title: "Method",
-        description: "Methods are the processes and procedures used to guide participatory politics and governance."
-      },
-      {
-        slug: "organizations",
-        title: "Organization",
-        description: "Organizations are profiles of formal and informal groups that design, implement, or support innovations in participatory politics and governance."
-      },
-      {
-        slug: "tools-techniques",
-        title: "Tools & Techniques",
-        description: "Description TBD"
-      },
-    ];
+    return contentTypesData;
   },
 
   getYearFromDate(date, format) {

--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -75,8 +75,7 @@ module.exports = {
   placeholder: (staticText, name) =>
     staticTextValue(staticText, name, "placeholder"),
 
-  staticText: (staticText, key) => staticTextValue(staticText, key),
-  t: (staticText, key) => staticTextValue(staticText, key), // duplicate short function name
+  t: (staticText, key) => staticTextValue(staticText, key),
 
   getArticleOptions: (staticText, name) => {
     // has_components and is_component_of fields use the cases options

--- a/app.js
+++ b/app.js
@@ -10,7 +10,9 @@ const handlebarsHelpers = require("./api/helpers/handlebars-helpers.js");
 const cookieParser = require('cookie-parser');
 
 // static text js objects
+const sharedStaticText = require("./static-text/shared-static-text.js");
 const aboutStaticText = require("./static-text/about-static-text.js");
+const researchStaticText = require("./static-text/research-static-text.js");
 
 var hbs = exphbs.create({
   // Specify helpers which are only registered on this instance.
@@ -115,13 +117,15 @@ app.use("/user", user);
 app.use("/bookmark", bookmark);
 
 app.get('/about', function (req, res) {
-  res.status(200).render("about-view", { static: aboutStaticText });
+  const staticText = Object.assign({}, sharedStaticText, aboutStaticText);
+  res.status(200).render("about-view", { static: staticText });
 });
 app.get('/legal', function (req, res) {
   res.status(200).render("legal-view");
 });
 app.get('/research', function (req, res) {
-  res.status(200).render("research-view");
+  const staticText = Object.assign({}, sharedStaticText, researchStaticText);
+  res.status(200).render("research-view", { static: staticText });
 });
 app.get('/teaching', function (req, res) {
   res.status(200).render("teaching-view");

--- a/app.js
+++ b/app.js
@@ -9,6 +9,9 @@ const fs = require("fs");
 const handlebarsHelpers = require("./api/helpers/handlebars-helpers.js");
 const cookieParser = require('cookie-parser');
 
+// static text js objects
+const aboutStaticText = require("./static-text/about-static-text.js");
+
 var hbs = exphbs.create({
   // Specify helpers which are only registered on this instance.
   defaultLayout: "main",
@@ -112,7 +115,7 @@ app.use("/user", user);
 app.use("/bookmark", bookmark);
 
 app.get('/about', function (req, res) {
-  res.status(200).render("about-view");
+  res.status(200).render("about-view", { static: aboutStaticText });
 });
 app.get('/legal', function (req, res) {
   res.status(200).render("legal-view");

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const cookieParser = require('cookie-parser');
 const sharedStaticText = require("./static-text/shared-static-text.js");
 const aboutStaticText = require("./static-text/about-static-text.js");
 const researchStaticText = require("./static-text/research-static-text.js");
+const teachingStaticText = require("./static-text/teaching-static-text.js");
 
 var hbs = exphbs.create({
   // Specify helpers which are only registered on this instance.
@@ -128,7 +129,10 @@ app.get('/research', function (req, res) {
   res.status(200).render("research-view", { static: staticText });
 });
 app.get('/teaching', function (req, res) {
-  res.status(200).render("teaching-view");
+  const staticText = Object.assign({}, sharedStaticText, teachingStaticText);
+  res.status(200).render("teaching-view", {
+    static: staticText,
+  });
 });
 app.get('/content-chooser', function (req, res) {
   res.status(200).render("content-chooser");

--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ const sharedStaticText = require("./static-text/shared-static-text.js");
 const aboutStaticText = require("./static-text/about-static-text.js");
 const researchStaticText = require("./static-text/research-static-text.js");
 const teachingStaticText = require("./static-text/teaching-static-text.js");
+const contentTypesText = require("./static-text/content-types-static-text.js");
 
 var hbs = exphbs.create({
   // Specify helpers which are only registered on this instance.
@@ -135,7 +136,10 @@ app.get('/teaching', function (req, res) {
   });
 });
 app.get('/content-chooser', function (req, res) {
-  res.status(200).render("content-chooser");
+  const staticText = Object.assign({}, sharedStaticText, contentTypesText);
+  res.status(200).render("content-chooser", {
+    static: staticText,
+  });
 });
 
 app.use("/s3/:path", checkJwtRequired);

--- a/localization.md
+++ b/localization.md
@@ -1,14 +1,19 @@
 # Localization
 
-### Templates expect each route that returns html to return a static key on the json response object that contains key/value pairs of the string key and the localized value.
+### What templates expect
+Each route that returns html should return a `static` key on the data object that contains key/value pairs of the string key and the localized value.
 
 ```
+// example response
+res.status(200).render("about-view", { static: {
+  "stringKey": "my string value",
+});
+
+// payload
 {
   "static": {
-    "stringKey": "stringValue",
-    ...
+    "stringKey": "my string value",
   },
-  ...
 }
 ```
 

--- a/localization.md
+++ b/localization.md
@@ -1,15 +1,6 @@
 # Localization
 
-## Backend
-
-### How to add new keys to the db
-
-
-----------
-
-## Front-End
-
-### Templates expect each route that returns html to return a static key on the json response object.
+### Templates expect each route that returns html to return a static key on the json response object that contains key/value pairs of the string key and the localized value.
 
 ```
 {
@@ -21,11 +12,14 @@
 }
 ```
 
-### Handlebars Helper
-{{t static key}}
+### Rendering localized text in HBS templates
+Use the `t` helper function and pass the static object with the key of the string you wish to render.
+```
+<p>{{t static "research.surveys.p1"}}</p>
+```
 
 ### Key Best Practices
-- for single words and short titles or phrases, use the actual text as the key
+- for single words and short titles or phrases, use the actual text as the key.
 ```
 "static": {
   "Cases": "Cases",
@@ -38,9 +32,12 @@
 ```
 "static": {
   "about.cases.p1": "Cases are events and instances of participatory politics and governance of all shapes and sizes.",
-  "about.cases.p2": "",
-  "about.tagline": "A global community sharing knowledge and stories about public participation",
-  "research.tagline": "Some other tag line",
+
+  "about.ckmc.title": "Communications & Knowledge Mobilization Committee",
+
+  "research.tagline": "Participedia is guided by the research question: What kinds of participatory processes work best, for what purposes, and under what conditions?",
 }
 ```
 
+### Adding new strings to the DB
+TBD

--- a/localization.md
+++ b/localization.md
@@ -1,0 +1,46 @@
+# Localization
+
+## Backend
+
+### How to add new keys to the db
+
+
+----------
+
+## Front-End
+
+### Templates expect each route that returns html to return a static key on the json response object.
+
+```
+{
+  "static": {
+    "stringKey": "stringValue",
+    ...
+  },
+  ...
+}
+```
+
+### Handlebars Helper
+{{t static key}}
+
+### Key Best Practices
+- for single words and short titles or phrases, use the actual text as the key
+```
+"static": {
+  "Cases": "Cases",
+  "Publish": "Publish",
+  "Project Director and Co-Founder": "Project Director and Co-Founder",
+}
+```
+
+- for page/section specific text use dot-notation to name space pages/sections
+```
+"static": {
+  "about.cases.p1": "Cases are events and instances of participatory politics and governance of all shapes and sizes.",
+  "about.cases.p2": "",
+  "about.tagline": "A global community sharing knowledge and stories about public participation",
+  "research.tagline": "Some other tag line",
+}
+```
+

--- a/static-text/about-static-text.js
+++ b/static-text/about-static-text.js
@@ -1,0 +1,49 @@
+const sharedStaticText = require("./shared-static-text.js");
+
+module.exports = Object.assign({}, sharedStaticText, {
+  "about.cases.p1": "Cases are events and instances of participatory politics and governance of all shapes and sizes.",
+
+  "about.ckmc.description": "The Communication and Knowledge Mobilization Committee is responsible for advising the Executive Committee on how communication with research partners can be planned, carried out, and refined. The CKM committee also advises on optimal communication with the Participedia user community, including supporting the development of content for the website, newsletter, and social media channels.",
+
+  "about.ckmc.title": "Communications & Knowledge Mobilization Committee",
+
+  "about.committees.p1": "Committees are comprised of project co-investigators and collaborators, each with one nominated chairperson who sits on the executive committee.",
+
+  "about.community.p1": "Participedia’s searchable database of democratic innovations is made up of three distinct content types including Cases, Methods and Organizations. Bolstering this knowledge base are added resources, including surveys, teaching tools and external data sets.",
+
+  "about.community.p2": "The initial vision for Participedia was developed by Archon Fung (Kennedy School of Government, Harvard University) and Mark E. Warren (Department of Political Science, University of British Columbia), and is guided by a set of standing committees.",
+
+  "about.content.p1": "Participedia offers a searchable database of content related to worldwide public participation.",
+
+  "about.contribute.p1": "Help improve the quality of this knowledge resource by editing existing content or publishing your own.",
+
+  "about.design_and_tech.description": "The Design & Technology Committee is responsible for the design and maintenance of the Participedia website.",
+
+  "about.explore.p1": `Search, read, download and gain insight from our database of <a href="/cases">Cases</a>, <a href="/methods">Methods</a>, <a href="/organizations">Organizations</a>, surveys, teaching resources and external data sets.`,
+
+  "about.funders.p1": "Participedia is currently supported by the Social Sciences and Humanities Research Council of Canada (SSHRC) in the form of a five-year Partnership Grant beginning in April 2015. A two-year SSHRC Partnership Grant was originally provided in April 2011. In 2012, The Bertelsmann Foundation provided generous support for development of multi-language functionality.",
+
+  "about.get_involved.p1": `Anyone can <a href="/login">join the Participedia community</a> and help crowdsource, catalogue and compare participatory political processes around the world. All content on Participedia is collaboratively produced and open-source under a <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons License</a>.`,
+
+  "about.members.p1": "Community members include policy analysts, democratic theorists, scholars, teachers, practitioners, activists, government officials, journalists and more. Anyone can join and help to build this growing resource by editing existing content or publishing new examples of public participation.",
+
+  "about.methods.p1": "Methods are the processes and procedures used to guide participatory politics and governance.",
+
+  "about.organizations.p1": "Organizations are profiles of formal and informal groups that design, implement, or support innovations in participatory politics and governance.",
+
+  "about.partners.p1": "Participedia reflects partnerships with organizations, institutions and individuals across the globe who share an interest in participatory politics and governance. Participedia’s partners are co-signers to the current SSHRC Partnership Grant. Please contact us if you would like to discuss developing a partnership to support Participedia’s global mission.",
+
+  "about.rdc.description": "The Research Design Committee is responsible for setting the strategic direction of PPedia’s research agenda.",
+
+  "about.rdc.title": "Research Design Committee",
+
+  "about.staff.p1": "Participedia employs a core staff to maintain day to day operations, support the community and ensure project goals are being met.",
+
+  "about.tagline": "A global community sharing knowledge and stories about public participation",
+
+  "about.teach.p1": "Use Participedia in the classroom as a tool to engage students and showcase their research.",
+
+  "about.ttmc.decription": "The Teaching Training and Mentoring Committee is responsible for developing outputs and implement actions for the integration of Participedia materials into pedagogy, teaching, student involvement and the training of practitioners and public officials.",
+
+  "about.ttmc.title": "Teaching Training & Mentoring Committee",
+});

--- a/static-text/about-static-text.js
+++ b/static-text/about-static-text.js
@@ -1,6 +1,4 @@
-const sharedStaticText = require("./shared-static-text.js");
-
-module.exports = Object.assign({}, sharedStaticText, {
+module.exports = {
   "about.cases.p1": "Cases are events and instances of participatory politics and governance of all shapes and sizes.",
 
   "about.ckmc.description": "The Communication and Knowledge Mobilization Committee is responsible for advising the Executive Committee on how communication with research partners can be planned, carried out, and refined. The CKM committee also advises on optimal communication with the Participedia user community, including supporting the development of content for the website, newsletter, and social media channels.",
@@ -46,4 +44,4 @@ module.exports = Object.assign({}, sharedStaticText, {
   "about.ttmc.decription": "The Teaching Training and Mentoring Committee is responsible for developing outputs and implement actions for the integration of Participedia materials into pedagogy, teaching, student involvement and the training of practitioners and public officials.",
 
   "about.ttmc.title": "Teaching Training & Mentoring Committee",
-});
+};

--- a/static-text/content-types-static-text.js
+++ b/static-text/content-types-static-text.js
@@ -1,0 +1,17 @@
+module.exports = {
+  "content_types.case": "Case",
+
+  "content_types.case.description": "Cases are specific events and instances of participatory politics and governance of all shapes and sizes. Cases can be contemporary or historical, completed, or ongoing.",
+
+  "content_types.method": "Method",
+
+  "content_types.method.description": "Methods are the processes and procedures used to guide participatory politics and governance.",
+
+  "content_types.organization": "Organization",
+
+  "content_types.organization.description": "Organizations are profiles of formal and informal groups that design, implement, or support innovations in participatory politics and governance.",
+
+  "content_types.tools-techniques": "Tools & Techniques",
+
+  "content_types.tools-techniques.description": "Description TBD",
+};

--- a/static-text/content-types-static-text.js
+++ b/static-text/content-types-static-text.js
@@ -1,19 +1,11 @@
 module.exports = {
   "content_types.header": "Select the type of content you would like to publish.",
 
-  "content_types.case": "Case",
-
   "content_types.case.description": "Cases are specific events and instances of participatory politics and governance of all shapes and sizes. Cases can be contemporary or historical, completed, or ongoing.",
-
-  "content_types.method": "Method",
 
   "content_types.method.description": "Methods are the processes and procedures used to guide participatory politics and governance.",
 
-  "content_types.organization": "Organization",
-
   "content_types.organization.description": "Organizations are profiles of formal and informal groups that design, implement, or support innovations in participatory politics and governance.",
-
-  "content_types.tools-techniques": "Tools & Techniques",
 
   "content_types.tools-techniques.description": "Description TBD",
 };

--- a/static-text/content-types-static-text.js
+++ b/static-text/content-types-static-text.js
@@ -1,4 +1,6 @@
 module.exports = {
+  "content_types.header": "Select the type of content you would like to publish.",
+
   "content_types.case": "Case",
 
   "content_types.case.description": "Cases are specific events and instances of participatory politics and governance of all shapes and sizes. Cases can be contemporary or historical, completed, or ongoing.",

--- a/static-text/research-static-text.js
+++ b/static-text/research-static-text.js
@@ -1,15 +1,27 @@
 module.exports = {
   "research.brazilian_data_set_link": "Dataset on Brazilian Participatory Budgeting: 1989 to 2012",
+
   "research.data_repository.header": "Data Repository",
+
   "research.data_repository.p1": "A great deal of research on democratic innovations is not publicly available. This includes large datasets, graduate and postgraduate dissertations, and practitioner evaluations and reports. We aim to find a home for such research in an accessible data repository.",
+
   "research.header": "Research",
+
   "research.methodology.header": "Methodology",
+
   "research.methodology.p1": "The strategy is simple: crowdsource data on democratic innovations from around the world and then aggregate this into a public database that continually updates with new contributions. All of Participedia’s content and data is open source.",
+
   "research.methodology.p2": "For an in-depth explanation of the history, aspirations, theory and analytical approach of Participedia, see [needs-link]The Participedia Project: An Introduction [/needs-link], by the two founders of Participedia, Archon Fung and Mark E. Warren.",
+
   "research.surveys.header": "Surveys",
+
   "research.surveys.p1": "Surveys are supplementary to Participedia’s current data and narrative descriptions and are intended to gain further insight on the outcomes and effects of cases.",
+
   "research.surveys.p2": "The participant survey will capture the experience of participants directly involved in a participatory process. It could be delivered by organizers at the location of a particular process, or participants could be asked to complete the survey after the event.",
+
   "research.surveys.p3": "The observer survey will capture views pertaining to the broader impact of a particular case. ‘Observers’ include practitioners, participants or researchers with particular knowledge of that case.",
+
   "research.surveys.p4": "Participedia's surveys are undergoing testing, and will be available for download soon.",
+
   "research.tagline": "Participedia is guided by the research question: What kinds of participatory processes work best, for what purposes, and under what conditions?",
 };

--- a/static-text/research-static-text.js
+++ b/static-text/research-static-text.js
@@ -1,11 +1,31 @@
 module.exports = {
-  "research.brazilian_data_set_link": "Dataset on Brazilian Participatory Budgeting: 1989 to 2012",
+  "research.data_repository.dataverse": "Participedia Dataverse Repository",
 
-  "research.data_repository.p1": "A great deal of research on democratic innovations is not publicly available. This includes large datasets, graduate and postgraduate dissertations, and practitioner evaluations and reports. We aim to find a home for such research in an accessible data repository.",
+  "research.data_repository.p1": "A great deal of research on democratic innovations and participatory processes that takes place around the world is not publicly available. These materials include datasets, codebooks, statistical software syntax or scripts, dissertations, conference papers, and practitioner evaluations and reports. The <a href=\"https://dataverse.harvard.edu/dataverse/Participedia\" target=\"_blank\">Participedia Dataverse</a> provides a home for these materials in an accessible and organized data repository, archives the materials for long-term preservation, and generates standardized descriptions and identifiers to ease discovery and citation of the materials.",
 
-  "research.methodology.p1": "The strategy is simple: crowdsource data on democratic innovations from around the world and then aggregate this into a public database that continually updates with new contributions. All of Participedia’s content and data is open source.",
+  "research.data_repository.p2": "Researchers and practitioners can contribute to the Participedia Dataverse by depositing their research materials free of charge. Features of the Participedia data repository include:",
 
-  "research.methodology.p2": "For an in-depth explanation of the history, aspirations, theory and analytical approach of Participedia, see [needs-link]The Participedia Project: An Introduction [/needs-link], by the two founders of Participedia, Archon Fung and Mark E. Warren.",
+  "research.data_repository.feature.1": "metrics on the number of downloads of each dataset;",
+
+  "research.data_repository.feature.2": "the ability to download datasets in multiple formats that are automatically generated;",
+
+  "research.data_repository.feature.3": "the ability to conduct data analysis right through the user interface without downloading data, since R is built into the user interface;",
+
+  "research.data_repository.feature.4": "long-term preservation of data;",
+
+  "research.data_repository.feature.5": "automatic assignment of digital object identifiers (DOIs) and other standards-compliant metadata to enable citation of datasets;",
+
+  "research.data_repository.feature.6": "indexing of datasets in major search engines to help users find the data;",
+
+  "research.data_repository.feature.7": "creation of digital fingerprints to enable authentication of datasets; and",
+
+  "research.data_repository.feature.8": "an open API that allows data and metadata to be used by other web services.",
+
+  "research.data_repository.questions": "Please direct any questions you may have about how to contribute to Participedia Dataverse to <a href=\"mailto:data@participedia.net\">data@participedia.net</a>",
+
+  "research.methodology.p1": "The strategy is simple: crowdsource information on democratic innovations from around the world and then aggregate this into a public database that continually updates with new contributions. All of Participedia’s content and data is open source.",
+
+  "research.methodology.p2": "For an in-depth explanation of the history, aspirations, theory, and analytical approach of Participedia, see '<a href=\"http://archonfung.net/docs/articles/2011/FungParticipedia201112.pdf\">The Participedia Project: An Introduction</a>', by the two founders of Participedia, Archon Fung and Mark E. Warren.",
 
   "research.surveys.p1": "Surveys are supplementary to Participedia’s current data and narrative descriptions and are intended to gain further insight on the outcomes and effects of cases.",
 

--- a/static-text/research-static-text.js
+++ b/static-text/research-static-text.js
@@ -1,0 +1,15 @@
+module.exports = {
+  "research.brazilian_data_set_link": "Dataset on Brazilian Participatory Budgeting: 1989 to 2012",
+  "research.data_repository.header": "Data Repository",
+  "research.data_repository.p1": "A great deal of research on democratic innovations is not publicly available. This includes large datasets, graduate and postgraduate dissertations, and practitioner evaluations and reports. We aim to find a home for such research in an accessible data repository.",
+  "research.header": "Research",
+  "research.methodology.header": "Methodology",
+  "research.methodology.p1": "The strategy is simple: crowdsource data on democratic innovations from around the world and then aggregate this into a public database that continually updates with new contributions. All of Participedia’s content and data is open source.",
+  "research.methodology.p2": "For an in-depth explanation of the history, aspirations, theory and analytical approach of Participedia, see [needs-link]The Participedia Project: An Introduction [/needs-link], by the two founders of Participedia, Archon Fung and Mark E. Warren.",
+  "research.surveys.header": "Surveys",
+  "research.surveys.p1": "Surveys are supplementary to Participedia’s current data and narrative descriptions and are intended to gain further insight on the outcomes and effects of cases.",
+  "research.surveys.p2": "The participant survey will capture the experience of participants directly involved in a participatory process. It could be delivered by organizers at the location of a particular process, or participants could be asked to complete the survey after the event.",
+  "research.surveys.p3": "The observer survey will capture views pertaining to the broader impact of a particular case. ‘Observers’ include practitioners, participants or researchers with particular knowledge of that case.",
+  "research.surveys.p4": "Participedia's surveys are undergoing testing, and will be available for download soon.",
+  "research.tagline": "Participedia is guided by the research question: What kinds of participatory processes work best, for what purposes, and under what conditions?",
+};

--- a/static-text/research-static-text.js
+++ b/static-text/research-static-text.js
@@ -1,19 +1,11 @@
 module.exports = {
   "research.brazilian_data_set_link": "Dataset on Brazilian Participatory Budgeting: 1989 to 2012",
 
-  "research.data_repository.header": "Data Repository",
-
   "research.data_repository.p1": "A great deal of research on democratic innovations is not publicly available. This includes large datasets, graduate and postgraduate dissertations, and practitioner evaluations and reports. We aim to find a home for such research in an accessible data repository.",
-
-  "research.header": "Research",
-
-  "research.methodology.header": "Methodology",
 
   "research.methodology.p1": "The strategy is simple: crowdsource data on democratic innovations from around the world and then aggregate this into a public database that continually updates with new contributions. All of Participedia’s content and data is open source.",
 
   "research.methodology.p2": "For an in-depth explanation of the history, aspirations, theory and analytical approach of Participedia, see [needs-link]The Participedia Project: An Introduction [/needs-link], by the two founders of Participedia, Archon Fung and Mark E. Warren.",
-
-  "research.surveys.header": "Surveys",
 
   "research.surveys.p1": "Surveys are supplementary to Participedia’s current data and narrative descriptions and are intended to gain further insight on the outcomes and effects of cases.",
 

--- a/static-text/shared-static-text.js
+++ b/static-text/shared-static-text.js
@@ -1,0 +1,23 @@
+// these are strings that might get used in multiple parts of the site
+
+module.exports = {
+  "Cases": "Cases",
+  "Co-investigators": "Co-investigators",
+  "Collaborators": "Collaborators",
+  "Committees": "Committees",
+  "Community": "Community",
+  "Content": "Content",
+  "Design & Technology Committee": "Design & Technology Committee",
+  "Executive Committee": "Executive Committee",
+  "Explore": "Explore",
+  "Funders": "Funders",
+  "Get Involved": "Get Involved",
+  "Join now": "Join now",
+  "Members": "Members",
+  "Methods": "Methods",
+  "Organizations": "Organizations",
+  "Partners": "Partners",
+  "Principal Investigator": "Principal Investigator",
+  "Staff": "Staff",
+  "Welcome to Participedia": "Welcome to Participedia",
+}

--- a/static-text/shared-static-text.js
+++ b/static-text/shared-static-text.js
@@ -1,23 +1,59 @@
 // these are strings that might get used in multiple parts of the site
 
 module.exports = {
+  "Teaching": "Teaching",
+
+  "Data Repository": "Data Repository",
+
+  "Research": "Research",
+
+  "Methodology": "Methodology",
+
+  "Method": "Method",
+
+  "Organization": "Organization",
+
+  "Surveys": "Surveys",
+
   "Cases": "Cases",
+
+  "Case": "Case",
+
+  "Tools & Techniques": "Tools & Techniques",
+
   "Co-investigators": "Co-investigators",
+
   "Collaborators": "Collaborators",
+
   "Committees": "Committees",
+
   "Community": "Community",
+
   "Content": "Content",
+
   "Design & Technology Committee": "Design & Technology Committee",
+
   "Executive Committee": "Executive Committee",
+
   "Explore": "Explore",
+
   "Funders": "Funders",
+
   "Get Involved": "Get Involved",
+
   "Join now": "Join now",
+
   "Members": "Members",
+
   "Methods": "Methods",
+
   "Organizations": "Organizations",
+
   "Partners": "Partners",
+
   "Principal Investigator": "Principal Investigator",
+
   "Staff": "Staff",
+
   "Welcome to Participedia": "Welcome to Participedia",
 }

--- a/static-text/teaching-static-text.js
+++ b/static-text/teaching-static-text.js
@@ -1,0 +1,18 @@
+module.exports = {
+  "teaching.header": "Teaching",
+  "teaching.in_the_classroom": "Participedia in the Classroom",
+  "teaching.in_the_classroom.p1": "Writing or editing articles for Participedia can be a great assignment for courses that deal with political participation, democratic innovation, or deliberation.",
+  "teaching.in_the_classroom.p2": "Writing or editing articles for Participedia can be a great assignment for courses that deal with political participation, democratic innovation, or deliberation.",
+  "teaching.in_the_classroom.p3": "Writing or editing articles for Participedia can be a great assignment for courses that deal with political participation, democratic innovation, or deliberation.",
+  "teaching.in_course": "Participedia In Course Assignments",
+  "teaching.Sample Assignment": "Sample Assignment",
+  "teaching.Grading Rubric": "Grading Rubric",
+  "teaching.tlrc.header": "Teaching & Learning Resource Centre",
+  "teaching.tlrc.p1": "Coming soon! Like cases, methods and organizations, anyone will be able to publish teaching and learning resources to share with the Participedia community.",
+  "teaching.tlrc.p2": "Currently, Participedia is collecting tools for educators and learners, including course syllabi, sample assignments and more, to enhance course offerings about public participation as well as participatory teaching practices in other subjects. These resources can be applied in early to post-secondary education settings, as well as professional development for NGOs, civil society organizations, and practitioners.",
+  "teaching.tlrc.resources": "These resources can be used to:",
+  "teaching.tlrc.resources.1": "Improve students’ knowledge of innovations in participatory democracy, while also improving their research and writing skills by publishing cases, methods and organizations on Participedia;",
+  "teaching.tlrc.resources.2": "Focus on Participedia content and its connection to relevant theoretical material;",
+  "teaching.tlrc.resources.3": "Prepare students to be organizers and researchers of democratic innovations, and;",
+  "teaching.tlrc.resources.4": "Shape pedagogy and classroom culture to be more participatory.",
+};

--- a/static-text/teaching-static-text.js
+++ b/static-text/teaching-static-text.js
@@ -1,18 +1,33 @@
 module.exports = {
   "teaching.header": "Teaching",
+
   "teaching.in_the_classroom": "Participedia in the Classroom",
+
   "teaching.in_the_classroom.p1": "Writing or editing articles for Participedia can be a great assignment for courses that deal with political participation, democratic innovation, or deliberation.",
+
   "teaching.in_the_classroom.p2": "Writing or editing articles for Participedia can be a great assignment for courses that deal with political participation, democratic innovation, or deliberation.",
+
   "teaching.in_the_classroom.p3": "Writing or editing articles for Participedia can be a great assignment for courses that deal with political participation, democratic innovation, or deliberation.",
+
   "teaching.in_course": "Participedia In Course Assignments",
+
   "teaching.Sample Assignment": "Sample Assignment",
+
   "teaching.Grading Rubric": "Grading Rubric",
+
   "teaching.tlrc.header": "Teaching & Learning Resource Centre",
+
   "teaching.tlrc.p1": "Coming soon! Like cases, methods and organizations, anyone will be able to publish teaching and learning resources to share with the Participedia community.",
+
   "teaching.tlrc.p2": "Currently, Participedia is collecting tools for educators and learners, including course syllabi, sample assignments and more, to enhance course offerings about public participation as well as participatory teaching practices in other subjects. These resources can be applied in early to post-secondary education settings, as well as professional development for NGOs, civil society organizations, and practitioners.",
+
   "teaching.tlrc.resources": "These resources can be used to:",
+
   "teaching.tlrc.resources.1": "Improve students’ knowledge of innovations in participatory democracy, while also improving their research and writing skills by publishing cases, methods and organizations on Participedia;",
+
   "teaching.tlrc.resources.2": "Focus on Participedia content and its connection to relevant theoretical material;",
+
   "teaching.tlrc.resources.3": "Prepare students to be organizers and researchers of democratic innovations, and;",
+
   "teaching.tlrc.resources.4": "Shape pedagogy and classroom culture to be more participatory.",
 };

--- a/static-text/teaching-static-text.js
+++ b/static-text/teaching-static-text.js
@@ -1,6 +1,4 @@
 module.exports = {
-  "teaching.header": "Teaching",
-
   "teaching.in_the_classroom": "Participedia in the Classroom",
 
   "teaching.in_the_classroom.p1": "Writing or editing articles for Participedia can be a great assignment for courses that deal with political participation, democratic innovation, or deliberation.",

--- a/views/about-view.html
+++ b/views/about-view.html
@@ -1,105 +1,86 @@
 <div class="static-view-container">
-  <h1>Welcome to Participedia</h1>
-  <h2>A global community sharing knowledge and stories about public participation</h2>
+  <h1>{{t static "Welcome to Participedia"}}</h1>
+  <h2>{{t static "about.tagline"}}</h2>
 
   <div class="video-embed-container">
     <iframe src='https://player.vimeo.com/video/219546454' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
   </div>
 
   <section>
-    <h2>Get Involved</h2>
-    <p>Anyone can <a href="/login">join the Participedia community</a> and help crowdsource, catalogue and compare participatory political processes around the world. All content on Participedia is collaboratively produced and open-source under a <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons License</a>.</p>
+    <h2>{{t static "Get Involved"}}</h2>
+    <p>{{{t static "about.get_involved.p1"}}}</p>
 
-    <h3>Explore</h3>
-    <p>Search, read, download and gain insight from our database of <a href="/cases">Cases</a>, <a href="/methods">Methods</a>, <a href="/organizations">Organizations</a>, surveys, teaching resources and external data sets.</p>
+    <h3>{{t static "Explore"}}</h3>
+    <p>{{{t static "about.explore.p1"}}}</p>
 
-    <h3>Contribute</h3>
-    <p>Help improve the quality of this knowledge resource by editing existing content or publishing your own.</p>
+    <h3>{{t static "Contribute"}}</h3>
+    <p>{{t static "about.contribute.p1"}}</p>
 
-    <h3>Teach</h3>
-    <p>Use Participedia in the classroom as a tool to engage students and showcase their research.</p>
+    <h3>{{t static "Teach"}}</h3>
+    <p>{{t static "about.teach.p1"}}</p>
   </section>
 
   <section>
-    <h2>Community</h2>
-    <p>Participedia’s searchable database of democratic innovations is made up of three distinct content types including Cases, Methods and Organizations. Bolstering this knowledge base are added resources, including surveys, teaching tools and external data sets.</p>
-
-    <p>The initial vision for Participedia was developed by Archon Fung (Kennedy School of Government, Harvard University) and Mark E. Warren (Department of Political Science, University of British Columbia), and is guided by a set of standing committees.</p>
+    <h2>{{t static "Community"}}</h2>
+    <p>{{t static "about.community.p1"}}</p>
+    <p>{{t static "about.community.p2"}}</p>
   </section>
 
   <section>
-    {{#> accordion title="Members"}}
-      <p>Community members include policy analysts, democratic theorists, scholars, teachers, practitioners, activists, government officials, journalists and more. Anyone can join and help to build this growing resource by editing existing content or publishing new examples of public participation.</p>
+    {{#> accordion title=(t static "Members")}}
+      <p>{{t static "about.members.p1"}}</p>
 
-      <p><a href="/login">Join now</a></p>
+      <p><a href="/login">{{t static "Join now"}}</a></p>
     {{/accordion}}
 
-    {{#> accordion title="Partners"}}
-      <p>Participedia reflects partnerships with organizations, institutions and individuals across the globe who share an interest in participatory politics and governance. Participedia’s partners are co-signers to the current SSHRC Partnership Grant. Please contact us if you would like to discuss developing a partnership to support Participedia’s global mission.</p>
+    {{#> accordion title=(t static "Partners")}}
+      <p>{{t static "about.partners.p1"}}</p>
 
       {{#each (getPartnersData)}}
-        {{> about-section}}
+        {{> about-section static=../static}}
       {{/each}}
     {{/accordion}}
 
-    {{#> accordion title="Committees"}}
-      <p>Committees are comprised of project co-investigators and collaborators, each with one nominated chairperson who sits on the executive committee.</p>
-
+    {{#> accordion title=(t static "Committees")}}
+      <p>{{about.committees.p1}}</p>
       {{#each (getCommitteesData)}}
-        {{> about-section}}
+        {{> about-section static=../static}}
       {{/each}}
     {{/accordion}}
 
-    {{#> accordion title="Funders"}}
-      <p>Participedia is currently supported by the Social Sciences and Humanities Research Council of Canada (SSHRC) in the form of a five-year Partnership Grant beginning in April 2015. A two-year SSHRC Partnership Grant was originally provided in April 2011. In 2012, The Bertelsmann Foundation provided generous support for development of multi-language functionality.</p>
+    {{#> accordion title=(t static "Funders")}}
+      <p>{{t static "about.funders.p1"}}</p>
     {{/accordion}}
 
-    {{#> accordion title="Staff"}}
-      <p>Participedia employs a core staff to maintain day to day operations, support the community and ensure project goals are being met.</p>
+    {{#> accordion title=(t static "Staff")}}
+      <p>{{t static "about.staff.p1"}}</p>
 
-      <dl class="people">
-        <dt>David Ascher, Technical Lead, Design & Technology Committee</dt>
-        {{# each descriptors}}
-          <dd>{{this}}</dd>
-        {{/each}}
-      </dl>
+      {{#each (getStaffData)}}
+        <dl class="people">
+          <dt>{{name}}{{#if titleKey}}, {{t static titleKey}}{{/if}}</dt>
+          {{# each descriptors}}
+            <dd>{{this}}</dd>
+          {{/each}}
+        </dl>
+      {{/each}}
 
-      <dl class="people">
-        <dt>Jesi Carson, Design & Communities Coordinator</dt>
-        <dd>Emily Carr University of Art + Design</dd>
-      </dl>
-
-      <dl class="people">
-        <dt>Rebecca Monnerat, Project Manager</dt>
-        <dd>University of British Columbia</dd>
-      </dl>
-
-      <dl class="people">
-        <dt>Patrick L. Scully, (member ex officio), Managing Director</dt>
-      </dl>
-
-      <dl class="people">
-        <dt>Mark E. Warren, Project Director and Co-Founder</dt>
-        <dd>Department of Political Science / Centre for the Study of Democratic Institutions</dd>
-        <dd>University of British Columbia</dd>
-      </dl>
     {{/accordion}}
   </section>
 
   <section>
-    <h2>Content</h2>
-    <p>Participedia offers a searchable database of content related to worldwide public participation.</p>
+    <h2>{{t static "Content"}}</h2>
+    <p>{{t static "about.content.p1"}}</p>
 
-    {{#> accordion title="Cases"}}
-      <p>Cases are events and instances of participatory politics and governance of all shapes and sizes.</p>
+    {{#> accordion title=(t static "Cases")}}
+      <p>{{t static "about.cases.p1"}}</p>
     {{/accordion}}
 
-    {{#> accordion title="Methods"}}
-      <p>Methods are the processes and procedures used to guide participatory politics and governance.</p>
+    {{#> accordion title=(t static "Methods")}}
+      <p>{{t static "about.methods.p1"}}</p>
     {{/accordion}}
 
-    {{#> accordion title="Organizations"}}
-      <p>Organizations are profiles of formal and informal groups that design, implement, or support innovations in participatory politics and governance.</p>
+    {{#> accordion title=(t static "Organizations")}}
+      <p>{{t static "about.organizations.p1"}}</p>
     {{/accordion}}
   </section>
 </div>

--- a/views/case-edit.html
+++ b/views/case-edit.html
@@ -1,7 +1,7 @@
 {{#> edit-form}}
   <fieldset class="overview">
-    <h2 class="fieldset-header">{{staticText static "overview_sectionlabel"}}</h2>
-    <h2 class="fieldset-header quickonly">{{staticText static "quick_submit_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "overview_sectionlabel"}}</h2>
+    <h2 class="fieldset-header quickonly">{{t static "quick_submit_sectionlabel"}}</h2>
     {{> article-edit-text name="title" is_required=true quick-submit=true}}
     {{> edit-multi-select ranked=true name="general_issues" quick-submit=true max=3 }}
     {{> edit-multi-select ranked=true name="specific_topics" max=3 }}
@@ -14,17 +14,17 @@
     {{> edit-multi-select name="tags" }}
   </fieldset>
   <fieldset class="location">
-    <h2 class="fieldset-header">{{staticText static "location_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "location_sectionlabel"}}</h2>
     {{> article-edit-location quick-submit=true}}
     {{> article-edit-select name="scope" }}
   </fieldset>
   <fieldset class="components fullonly">
-    <h2 class="fieldset-header">{{staticText static "components_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "components_sectionlabel"}}</h2>
     {{> edit-multi-select name="has_components" }}
     {{> edit-multi-select name="is_component_of" }}
   </fieldset>
   <fieldset class="media">
-    <h2 class="fieldset-header">{{staticText static "media_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "media_sectionlabel"}}</h2>
     {{> edit-link-set name="links" quick-submit=true}}
     {{> edit-media name="files" quick-submit=true}}
     {{> edit-media name="photos" type="image" quick-submit=true}}
@@ -32,27 +32,27 @@
     {{> edit-link-set name="audio" quick-submit=true}}
   </fieldset>
   <fieldset class="date_and_duration">
-    <h2 class="fieldset-header">{{staticText static "date_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "date_sectionlabel"}}</h2>
     {{> edit-date name="start_date" quick-submit=true}}
     {{> edit-date name="end_date" quick-submit=true}}
     {{> edit-boolean name="ongoing" quick-submit=true}}
     {{> article-edit-select name="time_limited" }}
   </fieldset>
   <fieldset class="purpose_and_approach fullonly">
-    <h2 class="fieldset-header">{{staticText static "purpose_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "purpose_sectionlabel"}}</h2>
     {{> edit-multi-select ranked=true name="purposes" max=3 }}
     {{> edit-multi-select ranked=true name="approaches" max=3 }}
     {{> article-edit-select name="public_spectrum" }}
   </fieldset>
   <fieldset class="participants fullonly">
-    <h2 class="fieldset-header">{{staticText static "participants_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "participants_sectionlabel"}}</h2>
     {{> edit-number name="number_of_participants" }}
     {{> article-edit-select name="open_or_limited" }}
     {{> article-edit-select name="recruitment_method" }}
     {{> edit-multi-select name="targeted_participants" max=3 }}
   </fieldset>
   <fieldset class="process fullonly">
-    <h2 class="fieldset-header">{{staticText static "process_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "process_sectionlabel"}}</h2>
     {{> edit-multi-select ranked=true name="method_types" max=3 }}
     {{> edit-multi-select ranked=true name="tools_techniques_types" max=3 }}
     {{> edit-multi-select name="specific_methods_tools_techniques" }}
@@ -67,19 +67,19 @@
     {{> edit-multi-select name="insights_outcomes" max=3 }}
   </fieldset>
   <fieldset class="organizations_and_supporters fullonly">
-    <h2 class="fieldset-header">{{staticText static "organizers_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "organizers_sectionlabel"}}</h2>
     {{> article-edit-select name="primary_organizer" }} <!-- missing organizations in static json -->
     {{> edit-multi-select name="organizer_types" max=3 }}
   </fieldset>
   <fieldset class="resources fullonly">
-    <h2 class="fieldset-header">{{staticText static "resources_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "resources_sectionlabel"}}</h2>
     {{> article-edit-text name="funder" }}
     {{> edit-multi-select name="funder_types" max=3 }}
     {{> article-edit-select name="staff" }}
     {{> article-edit-select name="volunteers" }}
   </fieldset>
   <fieldset class="evidence_of_impact fullonly">
-    <h2 class="fieldset-header">{{staticText static "evidence_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "evidence_sectionlabel"}}</h2>
     {{> article-edit-select name="impact_evidence" }}
     {{> edit-multi-select ranked=true name="change_types" max=5 }}
     {{> edit-multi-select ranked=true name="implementers_of_change" max=3 }}

--- a/views/content-chooser.html
+++ b/views/content-chooser.html
@@ -1,15 +1,15 @@
 <div class="static-view-container">
-  <h2>Select the type of content you would like to publish.</h2>
+  <h2>{{t static "content_types.header"}}</h2>
 
   <ul class="unstyled-list">
     {{#each (getContentTypeData)}}
       <li>
         <a href="/{{slug}}/new" class="button button-red button-block">
           {{> icon-add}}
-          {{title}}
+          {{t ../static titleKey}}
 
         </a>
-        <p>{{description}}</p>
+        <p>{{t ../static descriptionKey}}</p>
       </li>
     {{/each}}
   </ul>

--- a/views/organization-edit.html
+++ b/views/organization-edit.html
@@ -1,7 +1,7 @@
 {{#> edit-form}}
   <fieldset>
-    <h2 class="fieldset-header">{{staticText static "overview_sectionlabel"}}</h2>
-    <h2 class="fieldset-header quickonly">{{staticText static "quick_submit_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "overview_sectionlabel"}}</h2>
+    <h2 class="fieldset-header quickonly">{{t static "quick_submit_sectionlabel"}}</h2>
 
     {{> article-edit-text name="name" is_required=true quick-submit=true}}
     {{> article-edit-location}}
@@ -9,7 +9,7 @@
   </fieldset>
 
   <fieldset>
-    <h2 class="fieldset-header">{{staticText static "description_narrative_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "description_narrative_sectionlabel"}}</h2>
 
     {{> edit-textarea name="brief_description" quick-submit=true charLimit=280}}
     {{> edit-richtext
@@ -20,7 +20,7 @@
   </fieldset>
 
   <fieldset class="fullonly">
-    <h2 class="fieldset-header">{{staticText static "focus_areas_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "focus_areas_sectionlabel"}}</h2>
 
     {{> article-edit-select name="sector"}}
     {{> edit-multi-select name="general_issues" max=3}}
@@ -28,7 +28,7 @@
   </fieldset>
 
   <fieldset>
-    <h2 class="fieldset-header">{{staticText static "media_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "media_sectionlabel"}}</h2>
 
     {{> edit-media name="files" quick-submit=true}}
     {{> edit-link-set name="links" quick-submit=true}}
@@ -38,7 +38,7 @@
   </fieldset>
 
   <fieldset class="fullonly">
-    <h2 class="fieldset-header">{{staticText static "tools_techniques_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "tools_techniques_sectionlabel"}}</h2>
 
     {{> edit-multi-select name="type_method" max=3}}
     {{> edit-multi-select name="type_tool" max=3}}

--- a/views/partials/about-section.html
+++ b/views/partials/about-section.html
@@ -1,10 +1,10 @@
-{{#> accordion title=title small=true}}
-  {{#if description}}
-    <p>{{description}}</p>
+{{#> accordion title=(t static titleKey) small=true}}
+  {{#if descriptionKey}}
+    <p>{{t static descriptionKey}}</p>
   {{/if}}
   {{#each members}}
     <dl class="people">
-      <dt>{{name}}</dt>
+      <dt>{{name}}{{#if titleKey}}, {{t static titleKey}}{{/if}}</dt>
       {{# each descriptors}}
         <dd>{{this}}</dd>
       {{/each}}

--- a/views/research-view.html
+++ b/views/research-view.html
@@ -1,14 +1,14 @@
 <div class="static-view-container">
-  <h1>{{t static "research.header"}}</h1>
+  <h1>{{t static "Research"}}</h1>
   <h2>{{t static "research.tagline"}}</h2>
 
-  {{#> accordion title=(t static "research.methodology.header")}}
+  {{#> accordion title=(t static "Methodology")}}
     <p>{{t static "research.methodology.p1"}}</p>
 
     <p>{{t static "research.methodology.p2"}}</p>
   {{/accordion}}
 
-  {{#> accordion title=(t static "research.data_repository.header")}}
+  {{#> accordion title=(t static "Data Repository")}}
     <p>{{t static "research.data_repository.p1"}}</p>
 
     <p>
@@ -18,7 +18,7 @@
     </p>
   {{/accordion}}
 
-  {{#> accordion title=(t static "research.surveys.header")}}
+  {{#> accordion title=(t static "Surveys")}}
     <p>{{t static "research.surveys.p1"}}</p>
 
     <p>{{t static "research.surveys.p2"}}</p>

--- a/views/research-view.html
+++ b/views/research-view.html
@@ -1,30 +1,30 @@
 <div class="static-view-container">
-  <h1>Research</h1>
-  <h2>Participedia is guided by the research question: What kinds of participatory processes work best, for what purposes, and under what conditions?</h2>
+  <h1>{{t static "research.header"}}</h1>
+  <h2>{{t static "research.tagline"}}</h2>
 
-  {{#> accordion title="Methodology"}}
-    <p>The strategy is simple: crowdsource data on democratic innovations from around the world and then aggregate this into a public database that continually updates with new contributions. All of Participedia’s content and data is open source.</p>
+  {{#> accordion title=(t static "research.methodology.header")}}
+    <p>{{t static "research.methodology.p1"}}</p>
 
-    <p>For an in-depth explanation of the history, aspirations, theory and analytical approach of Participedia, see [needs-link]The Participedia Project: An Introduction [/needs-link], by the two founders of Participedia, Archon Fung and Mark E. Warren.</p>
+    <p>{{t static "research.methodology.p2"}}</p>
   {{/accordion}}
 
-  {{#> accordion title="Data Repository"}}
-    <p>A great deal of research on democratic innovations is not publicly available. This includes large datasets, graduate and postgraduate dissertations, and practitioner evaluations and reports. We aim to find a home for such research in an accessible data repository.</p>
+  {{#> accordion title=(t static "research.data_repository.header")}}
+    <p>{{t static "research.data_repository.p1"}}</p>
 
     <p>
       <a href="http://participedia.net/en/content/brazilian-participatory-budgeting-census">
-        Dataset on Brazilian Participatory Budgeting: 1989 to 2012
+        {{t static "research.brazilian_data_set_link"}}
       </a>
     </p>
   {{/accordion}}
 
-  {{#> accordion title="Surveys"}}
-    <p>Surveys are supplementary to Participedia’s current data and narrative descriptions and are intended to gain further insight on the outcomes and effects of cases.</p>
+  {{#> accordion title=(t static "research.surveys.header")}}
+    <p>{{t static "research.surveys.p1"}}</p>
 
-    <p>The participant survey will capture the experience of participants directly involved in a participatory process. It could be delivered by organizers at the location of a particular process, or participants could be asked to complete the survey after the event.</p>
+    <p>{{t static "research.surveys.p2"}}</p>
 
-    <p>The observer survey will capture views pertaining to the broader impact of a particular case. ‘Observers’ include practitioners, participants or researchers with particular knowledge of that case.</p>
+    <p>{{t static "research.surveys.p3"}}</p>
 
-    <p>Participedia's surveys are undergoing testing, and will be available for download soon.</p>
+    <p>{{t static "research.surveys.p4"}}</p>
   {{/accordion}}
 </div>

--- a/views/research-view.html
+++ b/views/research-view.html
@@ -5,17 +5,28 @@
   {{#> accordion title=(t static "Methodology")}}
     <p>{{t static "research.methodology.p1"}}</p>
 
-    <p>{{t static "research.methodology.p2"}}</p>
+    <p>{{{t static "research.methodology.p2"}}}</p>
   {{/accordion}}
 
   {{#> accordion title=(t static "Data Repository")}}
-    <p>{{t static "research.data_repository.p1"}}</p>
+    <p><strong>{{t static "research.data_repository.dataverse"}}</strong></p>
 
-    <p>
-      <a href="http://participedia.net/en/content/brazilian-participatory-budgeting-census">
-        {{t static "research.brazilian_data_set_link"}}
-      </a>
-    </p>
+    <p>{{{t static "research.data_repository.p1"}}}</p>
+
+    <p>{{t static "research.data_repository.p2"}}</p>
+
+    <ul>
+      <li>{{t static "research.data_repository.feature.1"}}</li>
+      <li>{{t static "research.data_repository.feature.2"}}</li>
+      <li>{{t static "research.data_repository.feature.3"}}</li>
+      <li>{{t static "research.data_repository.feature.4"}}</li>
+      <li>{{t static "research.data_repository.feature.5"}}</li>
+      <li>{{t static "research.data_repository.feature.6"}}</li>
+      <li>{{t static "research.data_repository.feature.7"}}</li>
+      <li>{{t static "research.data_repository.feature.8"}}</li>
+    </ul>
+
+    <p>{{{t static "research.data_repository.questions"}}}</p>
   {{/accordion}}
 
   {{#> accordion title=(t static "Surveys")}}

--- a/views/teaching-view.html
+++ b/views/teaching-view.html
@@ -1,5 +1,5 @@
 <div class="static-view-container">
-  <h1>{{t static "teaching.header"}}</h1>
+  <h1>{{t static "Teaching"}}</h1>
 
   <section>
     <h2>{{t static "teaching.in_the_classroom"}}</h2>

--- a/views/teaching-view.html
+++ b/views/teaching-view.html
@@ -1,44 +1,44 @@
 <div class="static-view-container">
-  <h1>Teaching</h1>
+  <h1>{{t static "teaching.header"}}</h1>
 
   <section>
-    <h2>Participedia in the Classroom</h2>
+    <h2>{{t static "teaching.in_the_classroom"}}</h2>
 
-    <p>Writing or editing articles for Participedia can be a great assignment for courses that deal with political participation, democratic innovation, or deliberation.</p>
+    <p>{{t static "teaching.in_the_classroom.p1"}}</p>
 
-    <p>In the course of selecting, researching, and writing up a case, method, or organization, students will learn about the substance of participation in varied contexts. Students may also find it rewarding to have their work showcased on Participedia.</p>
+    <p>{{t static "teaching.in_the_classroom.p2"}}</p>
 
-    <p>Participedia’s Teaching Training and Mentoring Committee has collected a variety of resources from the academic community. Feel free to adjust the material to suit your class’s needs.</p>
+    <p>{{t static "teaching.in_the_classroom.p3"}}</p>
 
-    {{#> accordion title="Participedia In Course Assignments"}}
+    {{#> accordion title=(t static "teaching.in_course")}}
       <p>
         <a href="http://participedia.net/content/participedia-sample-assignment-1-write-entry-case-method-or-organization">
-          Sample Assignment
+          {{t static "teaching.Sample Assignment"}}
         </a>
       </p>
 
       <p>
         <a href="http://participedia.net/content/sample-grading-rubric">
-          Grading Rubric
+          {{t static "teaching.Grading Rubric"}}
         </a>
       </p>
     {{/accordion}}
   </section>
 
   <section>
-    <h2>Teaching & Learning Resource Centre</h2>
+    <h2>{{t static "teaching.tlrc.header"}}</h2>
 
-    <p>Coming soon! Like cases, methods and organizations, anyone will be able to publish teaching and learning resources to share with the Participedia community.</p>
+    <p>{{t static "teaching.tlrc.p1"}}</p>
 
-    <p>Currently, Participedia is collecting tools for educators and learners, including course syllabi, sample assignments and more, to enhance course offerings about public participation as well as participatory teaching practices in other subjects. These resources can be applied in early to post-secondary education settings, as well as professional development for NGOs, civil society organizations, and practitioners.</p>
+    <p>{{t static "teaching.tlrc.p2"}}</p>
 
-    <p>These resources can be used to:</p>
+    <p>{{t static "teaching.tlrc.resources"}}</p>
 
     <ol>
-      <li>Improve students’ knowledge of innovations in participatory democracy, while also improving their research and writing skills by publishing cases, methods and organizations on Participedia;</li>
-      <li>Focus on Participedia content and its connection to relevant theoretical material;</li>
-      <li>Prepare students to be organizers and researchers of democratic innovations, and;</li>
-      <li>Shape pedagogy and classroom culture to be more participatory.</li>
+      <li>{{t static "teaching.tlrc.resources.1"}}</li>
+      <li>{{t static "teaching.tlrc.resources.2"}}</li>
+      <li>{{t static "teaching.tlrc.resources.3"}}</li>
+      <li>{{t static "teaching.tlrc.resources.4"}}</li>
     </ol>
   </section>
 </div>

--- a/views/tools-techniques-edit.html
+++ b/views/tools-techniques-edit.html
@@ -1,20 +1,20 @@
 {{#> edit-form}}
   <fieldset>
-    <h2 class="fieldset-header">{{staticText static "overview_sectionlabel"}}</h2>
-    <h2 class="fieldset-header quickonly">{{staticText static "quick_submit_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "overview_sectionlabel"}}</h2>
+    <h2 class="fieldset-header quickonly">{{t static "quick_submit_sectionlabel"}}</h2>
 
     {{> article-edit-text name="title" is_required=true quick-submit=true}}
     {{> article-edit-select name="facetoface_online_or_both" quick-submit=true}}
   </fieldset>
 
   <fieldset>
-    <h2 class="fieldset-header">{{staticText static "type_purpose_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "type_purpose_sectionlabel"}}</h2>
 
     {{> edit-multi-select name="type_tool" quick-submit=true max=3}}
   </fieldset>
 
   <fieldset>
-    <h2 class="fieldset-header">{{staticText static "description_narrative_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "description_narrative_sectionlabel"}}</h2>
 
     {{> edit-textarea name="brief_description" quick-submit=true charLimit=280}}
     {{> edit-richtext
@@ -25,7 +25,7 @@
   </fieldset>
 
   <fieldset>
-    <h2 class="fieldset-header">{{staticText static "media_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "media_sectionlabel"}}</h2>
 
     {{> edit-media name="files" quick-submit=true}}
     {{> edit-link-set name="links" quick-submit=true}}
@@ -35,13 +35,13 @@
   </fieldset>
 
   <fieldset class="fullonly">
-    <h2 class="fieldset-header">{{staticText static "participants_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "participants_sectionlabel"}}</h2>
 
     {{> edit-number name="number_of_participants" }}
   </fieldset>
 
    <fieldset class="fullonly">
-    <h2 class="fieldset-header">{{staticText static "process_sectionlabel"}}</h2>
+    <h2 class="fieldset-header">{{t static "process_sectionlabel"}}</h2>
 
     {{> edit-multi-select name="types_interaction" }}
     {{> article-edit-select name="facilitation" }}

--- a/views/user-edit.html
+++ b/views/user-edit.html
@@ -6,7 +6,7 @@
       {{else}}
         <div class="user-profile-image-initial">{{getInitials user.name}}</div>
       {{/if}}
-      <div class="user-profile-image-edit-overlay">{{staticText static "change"}}</div>
+      <div class="user-profile-image-edit-overlay">{{t static "change"}}</div>
     </a>
   </div>
   <div class="user-main-content">
@@ -17,34 +17,34 @@
       data-submit-type="full"
       class="js-edit-form"
     >
-      <p><strong>{{staticText static "member_since"}}</strong> {{moment user.join_date "ll"}}</p>
+      <p><strong>{{t static "member_since"}}</strong> {{moment user.join_date "ll"}}</p>
 
       <fieldset>
-        <h2>{{staticText static "public_profile"}}</h2>
+        <h2>{{t static "public_profile"}}</h2>
         {{> edit-text name="name" value=user.name placeholderText=static.name_placeholder}}
         {{> edit-text name="location" value=user.location placeholderText=static.location_placeholder}}
         {{> edit-richtext name="bio" value=user.bio}}
       </fieldset>
 
       <fieldset>
-        <h2>{{staticText static "private_settings"}}</h2>
+        <h2>{{t static "private_settings"}}</h2>
 
         {{> edit-text name="email" value=user.email placeholderText=static.email_placeholder}}
 
         {{#> edit-form-group name="password"}}
           <input
             type="password"
-            placeholder="{{staticText static "current_password_placeholder"}}"
+            placeholder="{{t static "current_password_placeholder"}}"
             name="current_password"
           />
           <input
             type="password"
-            placeholder="{{staticText static "new_password_placeholder"}}"
+            placeholder="{{t static "new_password_placeholder"}}"
             name="new_password"
           />
           <input
             type="password"
-            placeholder="{{staticText static "confirm_new_password_placeholder"}}"
+            placeholder="{{t static "confirm_new_password_placeholder"}}"
             name="confirm_new_password"
           />
         {{/edit-form-group}}
@@ -58,7 +58,7 @@
       </fieldset>
 
       <button type="submit" class="button button-light-grey">
-        {{> icon-submit }} {{staticText static "publish"}}
+        {{> icon-submit }} {{t static "publish"}}
       </button>
     </form>
   </div>

--- a/views/user-view.html
+++ b/views/user-view.html
@@ -1,7 +1,7 @@
 <div class="user-container user-view">
   <div class="user-profile-image">
     {{#if user.picture_url}}
-      <img src="{{user.picture_url}}" alt="{{staticText static "profile_picture"}}" width="160" height="160" />
+      <img src="{{user.picture_url}}" alt="{{t static "profile_picture"}}" width="160" height="160" />
     {{else}}
       <div class="user-profile-image-initial">{{getInitials user.name}}</div>
     {{/if}}
@@ -10,17 +10,17 @@
     {{!-- if user is logged in, show edit profile button --}}
     {{#if user.login}}
       <div class="user-view-edit-profile-button">
-        <a href="/user/{{user.id}}/edit" class="button button-red">{{staticText static "edit_profile"}}</a>
+        <a href="/user/{{user.id}}/edit" class="button button-red">{{t static "edit_profile"}}</a>
       </div>
     {{/if}}
 
     <h2 class="user-view-name">{{user.name}}</h2>
     {{#if user.location}}
-      <span class="small"><strong>{{staticText static "location"}}</strong> {{user.location}}</span></br>
+      <span class="small"><strong>{{t static "location"}}</strong> {{user.location}}</span></br>
     {{/if}}
     {{#if user.join_date}}
       <span class="small">
-        <strong>{{staticText static "member_since"}}</strong> {{getYearFromDate user.join_date}}
+        <strong>{{t static "member_since"}}</strong> {{getYearFromDate user.join_date}}
       </span>
       </br>
     {{/if}}


### PR DESCRIPTION
- rename/shorten staticText helper to `t` (for translate)
- move static text to json blobs so it can easily be added to the localization db for the following pages
-- About
-- Research
-- Teaching
-- Content Types
- adds [localization.md](https://github.com/participedia/api/blob/a929913921922448a9555acc369646ac2ae3e209/localization.md) file to document how to render localized text in templates
- update research content with revisions https://github.com/participedia/api/issues/429
