### PR TITLE
styling fixes from usersnap issues

### DIFF
--- a/public/css/header.css
+++ b/public/css/header.css
@@ -211,6 +211,8 @@ header a {
 .main-content {
   padding-top: 30px;
   margin-top: 60px;
+  /* make min height the height of the viewport minus height of footer, padding/margin, header, so that footer always looks fixed to bottom */
+  min-height: calc(100VH - 227px - 90px - 60px);
 }
 
 /* profile img/button with dropdown menu */

--- a/public/css/tabs-with-cards.css
+++ b/public/css/tabs-with-cards.css
@@ -106,6 +106,7 @@
 [data-card-layout="list"] .cards-container .article-card {
   border-bottom: 1px solid #e6e6e6;
   padding-bottom: 30px;
+  display: flex;
 }
 
 [data-card-layout="list"] .cards-container .article-card a {


### PR DESCRIPTION
-  On list view: Entry type, title text, short description, and submission details should be aligned to the top and right of the thumbnail image. fixes: https://github.com/participedia/usersnaps/issues/350
before:
<img width="1279" alt="Screenshot 2019-04-10 14 16 57" src="https://user-images.githubusercontent.com/130878/55914171-5247b380-5b9b-11e9-85fa-04f754c5462c.png">

after: 
<img width="1280" alt="Screenshot 2019-04-10 13 22 59" src="https://user-images.githubusercontent.com/130878/55914175-57a4fe00-5b9b-11e9-88cd-54fade56ab91.png">


- The footer should never float up above the bottom of the screen. fixes: https://github.com/participedia/usersnaps/issues/357
before: 
![Screenshot 2019-04-10 13 34 46](https://user-images.githubusercontent.com/130878/55914125-36441200-5b9b-11e9-93f3-0121d1686f1a.png)

after: 
![Screenshot 2019-04-10 13 34 57](https://user-images.githubusercontent.com/130878/55914131-393f0280-5b9b-11e9-8e6e-9bb3a7ce689e.png)


@jesicarson @dethe 