### PR TITLE
script to fix lat/lng for cases and organizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -361,6 +361,15 @@
         }
       }
     },
+    "@google/maps": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@google/maps/-/maps-0.5.5.tgz",
+      "integrity": "sha512-RSZriyE2XViVhXgdEcQaEu3jMYh2A/jS0VahLHXqGO0VfPyEbDac4PAn7/hBJiTavWpxchKfe5OI9inJofFWxA==",
+      "dev": true,
+      "requires": {
+        "uuid": ">=2.2.1"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
@@ -4308,327 +4317,117 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
-      "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+      "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
       "optional": true,
       "requires": {
-        "nan": "^2.3.0",
-        "node-pre-gyp": "^0.6.29"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "resolved": false,
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+          "version": "1.1.1",
+          "bundled": true,
           "optional": true
         },
         "ansi-regex": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-          "optional": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": false,
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "version": "2.1.1",
+          "bundled": true,
           "optional": true
         },
         "aproba": {
-          "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
+          "version": "1.2.0",
+          "bundled": true,
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+          "version": "1.1.5",
+          "bundled": true,
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
-            "readable-stream": "^2.0.0 || ^1.1.13"
+            "readable-stream": "^2.0.6"
           }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": false,
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": false,
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": false,
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": false,
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.5.0",
-          "resolved": false,
-          "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
-          "optional": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "resolved": false,
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "version": "1.0.0",
+          "bundled": true,
           "optional": true
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
-          "optional": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "resolved": false,
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "optional": true,
-          "requires": {
-            "inherits": "~2.0.0"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": false,
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "optional": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
         "brace-expansion": {
-          "version": "1.1.6",
-          "resolved": false,
-          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+          "version": "1.1.11",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "balanced-match": "^0.4.1",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
           "optional": true
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": false,
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "optional": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "optional": true
-            }
-          }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "optional": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "optional": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": false,
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "optional": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "optional": true
         },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": false,
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "optional": true,
-          "requires": {
-            "boom": "2.x.x"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": false,
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "optional": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "optional": true
-            }
-          }
-        },
         "debug": {
-          "version": "2.2.0",
-          "resolved": false,
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "4.1.1",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
-          "version": "0.4.1",
-          "resolved": false,
-          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "version": "0.6.0",
+          "bundled": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "optional": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "~0.1.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "optional": true
-        },
-        "extend": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "optional": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": false,
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-          "optional": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "optional": true
         },
-        "fstream": {
-          "version": "1.0.10",
-          "resolved": false,
-          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "inherits": "~2.0.0",
-            "mkdirp": ">=0.5 0",
-            "rimraf": "2"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "optional": true,
-          "requires": {
-            "fstream": "^1.0.0",
-            "inherits": "2",
-            "minimatch": "^3.0.0"
-          }
-        },
         "gauge": {
-          "version": "2.7.2",
-          "resolved": false,
-          "integrity": "sha1-Fc7MMbAtBTRaXWsOFxzbOtIwd3Q=",
+          "version": "2.7.4",
+          "bundled": true,
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -4638,128 +4437,46 @@
             "signal-exit": "^3.0.0",
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1",
-            "supports-color": "^0.2.0",
             "wide-align": "^1.1.0"
           }
         },
-        "generate-function": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-          "optional": true
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-          "optional": true,
-          "requires": {
-            "is-property": "^1.0.0"
-          }
-        },
-        "getpass": {
-          "version": "0.1.6",
-          "resolved": false,
-          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-          "optional": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "optional": true
-            }
-          }
-        },
         "glob": {
-          "version": "7.1.1",
-          "resolved": false,
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "version": "7.1.3",
+          "bundled": true,
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.2",
+            "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": false,
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "optional": true
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-          "optional": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": false,
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "optional": true,
-          "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "optional": true
         },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": false,
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": false,
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "optional": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -4768,382 +4485,251 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "optional": true
         },
         "ini": {
-          "version": "1.3.4",
-          "resolved": false,
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "version": "1.3.5",
+          "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
-        "is-my-json-valid": {
-          "version": "2.15.0",
-          "resolved": false,
-          "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-          "optional": true,
-          "requires": {
-            "generate-function": "^2.0.0",
-            "generate-object-property": "^1.1.0",
-            "jsonpointer": "^4.0.0",
-            "xtend": "^4.0.0"
-          }
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-          "optional": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "optional": true
-        },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "optional": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": false,
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "optional": true,
-          "requires": {
-            "jsbn": "~0.1.0"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": false,
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": false,
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "optional": true
-        },
-        "jsonpointer": {
-          "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          }
-        },
-        "mime-db": {
-          "version": "1.25.0",
-          "resolved": false,
-          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
-          "optional": true
-        },
-        "mime-types": {
-          "version": "2.1.13",
-          "resolved": false,
-          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-          "optional": true,
-          "requires": {
-            "mime-db": "~1.25.0"
-          }
         },
         "minimatch": {
-          "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "version": "3.0.4",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "optional": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": false,
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "version": "2.1.1",
+          "bundled": true,
           "optional": true
         },
-        "node-pre-gyp": {
-          "version": "0.6.32",
-          "resolved": false,
-          "integrity": "sha1-/EUrN25zGbPSVfXzSFPvb9j+H9U=",
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "mkdirp": "~0.5.1",
-            "nopt": "~3.0.6",
-            "npmlog": "^4.0.1",
-            "rc": "~1.1.6",
-            "request": "^2.79.0",
-            "rimraf": "~2.5.4",
-            "semver": "~5.3.0",
-            "tar": "~2.2.1",
-            "tar-pack": "~3.3.0"
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
-          "version": "3.0.6",
-          "resolved": false,
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "version": "4.0.1",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
-          "version": "4.0.2",
-          "resolved": false,
-          "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
+          "version": "4.1.2",
+          "bundled": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.1",
+            "gauge": "~2.7.3",
             "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": false,
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "bundled": true,
           "optional": true
         },
         "object-assign": {
-          "version": "4.1.0",
-          "resolved": false,
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+          "version": "4.1.1",
+          "bundled": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
           "optional": true
         },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
           "optional": true
         },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": false,
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "optional": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": false,
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "optional": true
-        },
-        "qs": {
-          "version": "6.3.0",
-          "resolved": false,
-          "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
+          "version": "2.0.0",
+          "bundled": true,
           "optional": true
         },
         "rc": {
-          "version": "1.1.6",
-          "resolved": false,
-          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
+          "version": "1.2.8",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "~0.4.0",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
-            "strip-json-comments": "~1.0.4"
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
-          "version": "2.2.2",
-          "resolved": false,
-          "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
+          "version": "2.3.6",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "buffer-shims": "^1.0.0",
             "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "inherits": "~2.0.3",
             "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
           }
         },
-        "request": {
-          "version": "2.79.0",
-          "resolved": false,
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
+            "glob": "^7.1.3"
           }
         },
-        "rimraf": {
-          "version": "2.5.4",
-          "resolved": false,
-          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
         },
         "semver": {
-          "version": "5.3.0",
-          "resolved": false,
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.7.0",
+          "bundled": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": false,
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "optional": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "sshpk": {
-          "version": "1.10.1",
-          "resolved": false,
-          "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
-          "optional": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jodid25519": "^1.0.0",
-            "jsbn": "~0.1.0",
-            "tweetnacl": "~0.14.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "optional": true
-            }
-          }
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -5152,158 +4738,61 @@
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "resolved": false,
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "optional": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": false,
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "optional": true
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-          "optional": true
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "resolved": false,
-          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "version": "2.0.1",
+          "bundled": true,
           "optional": true
         },
         "tar": {
-          "version": "2.2.1",
-          "resolved": false,
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "version": "4.4.8",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           }
-        },
-        "tar-pack": {
-          "version": "3.3.0",
-          "resolved": false,
-          "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
-          "optional": true,
-          "requires": {
-            "debug": "~2.2.0",
-            "fstream": "~1.0.10",
-            "fstream-ignore": "~1.0.5",
-            "once": "~1.3.3",
-            "readable-stream": "~2.1.4",
-            "rimraf": "~2.5.1",
-            "tar": "~2.2.1",
-            "uid-number": "~0.0.6"
-          },
-          "dependencies": {
-            "once": {
-              "version": "1.3.3",
-              "resolved": false,
-              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-              "optional": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "readable-stream": {
-              "version": "2.1.5",
-              "resolved": false,
-              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-              "optional": true,
-              "requires": {
-                "buffer-shims": "^1.0.0",
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
-              }
-            }
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "resolved": false,
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "optional": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": false,
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": false,
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "resolved": false,
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "optional": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "resolved": false,
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
         },
         "wide-align": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+          "version": "1.1.3",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.1"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "optional": true
         },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
           "optional": true
         }
       }
@@ -7425,9 +6914,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "optional": true
     },
     "natural-compare": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "winston": "^2.3.1"
   },
   "devDependencies": {
+    "@google/maps": "0.5.5",
     "auth0": "^2.14.0",
     "auth0-js": "^9.9.0",
     "auth0-lock": "^11.13.0",
@@ -71,8 +72,8 @@
     "esmify": "^2.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
-    "prettier": "^1.15.3",
     "npm-run-all": "^4.1.5",
+    "prettier": "^1.15.3",
     "watchify": "^3.11.0"
   },
   "scripts": {

--- a/scripts/geocode-address-for-lat-lng.js
+++ b/scripts/geocode-address-for-lat-lng.js
@@ -75,7 +75,7 @@ async function processArticles(type) {
           if (err) console.log("error:", err);
         });
     } else {
-      // if there is no address data, set lat/lng to NULL rather than 0° 0' 0" N,0° 0' 0" E
+      // if there is no address data, set lat/lng to NULL
       saveArticle(article.type, article.id, null, null).then(() => {
         console.log(`NULL - ${article.type} #${article.id} - There is no address data, setting lat/lng as null`);
       });

--- a/scripts/geocode-address-for-lat-lng.js
+++ b/scripts/geocode-address-for-lat-lng.js
@@ -1,0 +1,97 @@
+// - for all cases and organizations
+// - compose an address string from the following article
+//   location keys: address1, city, province, postal_code, country.
+// - if no address string exists (meaning location keys are all falsey),
+//   save lat/lng as null
+// - if address string exists, pass that address string to geocode
+//   service to get lat/lng and save new lat/lng.
+
+// to run: node scripts/geocode-address-for-lat-lng.js
+
+const GoogleMaps = require("@google/maps");
+const { db } = require("../api/helpers/db.js");
+
+const googleMapsClient = GoogleMaps.createClient({
+  key: process.env.GOOGLE_MAPS_GEOCODE_API_KEY,
+  Promise: Promise,
+});
+
+const MAP_TYPE_TO_DB_TABLE = {
+  case: "cases",
+  organization: "organizations",
+};
+
+function composeAddressString(article) {
+  const { address1, city, province, postal_code, country } = article;
+  const addressData = [address1, city, province, postal_code, country];
+  let addressString = "";
+  addressData.forEach((item, i) => {
+    // if item is not empty string, add to address string
+    if (item !== "") {
+      addressString = addressString + item;
+      if (i !== addressData.length - 1) {
+        // if it's not the last item, append a comma and space
+        addressString = addressString + ", ";
+      }
+    }
+  });
+  return addressString;
+}
+
+async function getAllArticlesForType(type) {
+  const sql = `
+    SELECT type, latitude, longitude, id, address1, city, province, postal_code, country
+    FROM ${MAP_TYPE_TO_DB_TABLE[type]};
+  `;
+  return db.any(sql).then(result => result).catch((err) => console.log("getAllArticlesForType err", err));
+}
+
+function saveArticle(type, id, lat, lng) {
+  const sql = `
+    UPDATE ${MAP_TYPE_TO_DB_TABLE[type]}
+    SET latitude = ${lat}, longitude = ${lng}
+    WHERE id = ${id};
+  `;
+  return db.any(sql).then(result => result).catch((err) => console.log("saveArticle err", err));;
+}
+
+async function processArticles(type) {
+  const articles = await getAllArticlesForType(type);
+  articles.forEach(function(article) {
+    const addressString = composeAddressString(article);
+    if (addressString !== "") {
+      // Geocode an address string to get lat/long
+      googleMapsClient
+        .geocode({ address: addressString })
+        .asPromise()
+        .then((response) => {
+          // set new lat lng on article object and save
+          const { lat, lng } = response.json.results[0].geometry.location;
+          saveArticle(article.type, article.id, lat, lng).then(() => {
+            console.log(`UPDATED - ${article.type} #${article.id} saved with lat: ${lat}, lng: ${lng}`);
+          });
+        })
+        .catch((err) => {
+          if (err) console.log("error:", err);
+        });
+    } else {
+      // if there is no address data, set lat/lng to NULL rather than 0° 0' 0" N,0° 0' 0" E
+      saveArticle(article.type, article.id, null, null).then(() => {
+        console.log(`NULL - ${article.type} #${article.id} - There is no address data, setting lat/lng as null`);
+      });
+    }
+  });
+}
+
+function start() {
+  if (!process.env.GOOGLE_MAPS_GEOCODE_API_KEY) {
+    console.log("*** Missing Google Maps Geocode API key. Add GOOGLE_MAPS_GEOCODE_API_KEY to your .env file ***")
+    console.log("https://developers.google.com/maps/documentation/geocoding/get-api-key")
+    return;
+  }
+
+  const types = Object.keys(MAP_TYPE_TO_DB_TABLE);
+  types.forEach(type => processArticles(type));
+}
+
+start();


### PR DESCRIPTION
@dethe here is my first run at fixing  lat/lng for cases and organizations. 

https://github.com/participedia/usersnaps/issues/351
https://github.com/participedia/api/issues/478

for all cases and organizations
- compose an address string from the following article
  location keys: address1, city, province, postal_code, country.
- if no address string exists (meaning location keys are all falsey),
   save lat/lng as null
- if address string exists, pass that address string to geocode
  service to get lat/lng and save new lat/lng.

running this script will fix the articles in the local db, but we will still need to fix the migration fixtures (ie: https://github.com/participedia/api/blob/master/migrations/cases.json) so when the db is reset we have the correct lat/lng data. any suggestions on best way to do this? i took a stab at generating the new fixtures by pulling the data from the db once this migration was run, and then writing a new fixture json file. but then when i run the migrations, i get errors and the case table doesn't get populated. how did you generate the existing json fixtures? 