### PR TITLE
edit form: update input field names and fix post_date bug

### DIFF
--- a/public/js/edit-submission-details.js
+++ b/public/js/edit-submission-details.js
@@ -2,18 +2,12 @@ import autocomplete from "autocompleter";
 
 const editSubmissionDetails = {
   init() {
-    const firstSubmittedAutoCompleteEl =
-      document.querySelector("input[name=creator_name]");
+    const firstSubmittedAutoCompleteEl = document.querySelector("#js-creator-name");
+    const firstSubmittedHiddenEl = document.querySelector("input[name=creator]");
+    const mostRecentChangeAutoCompleteEl = document.querySelector("#js-last-updated-by-name");
+    const mostRecentChangeHiddenEl = document.querySelector("input[name=last_updated_by]");
 
     if (!firstSubmittedAutoCompleteEl) return; // if submission field not present, don't continue
-
-    const firstSubmittedHiddenEl =
-      document.querySelector("input[name=creator_user_id]");
-
-    const mostRecentChangeAutoCompleteEl =
-      document.querySelector("input[name=last_updated_by_name]");
-    const mostRecentChangeHiddenEl =
-      document.querySelector("input[name=last_updated_by_user_id]");
 
     // get author data from ui
     const authors = this.getAuthorData();

--- a/views/partials/edit-submission-details.html
+++ b/views/partials/edit-submission-details.html
@@ -1,8 +1,8 @@
 <div class="edit-form-author-info">
 {{#if user.isadmin}}
-  <button class="button button-red edit-submission-details-btn js-edit-submission-details-btn">
+  <a class="button button-red edit-submission-details-btn js-edit-submission-details-btn">
     Edit Submission Details
-  </button>
+  </a>
 {{/if}}
 
 <div class="js-view-submission-details">
@@ -15,14 +15,14 @@
       <strong>First Submitted By</strong>
       <input
         type="text"
-        name="creator_name"
+        id="js-creator-name"
         value="{{article.creator.name}}"
         autocomplete="false"
         autocomplete="off"
       />
       <input
         type="hidden"
-        name="creator_user_id"
+        name="creator"
         value="{{article.creator.user_id}}"
       />
     </p>
@@ -30,7 +30,7 @@
       <strong>First Submitted Date</strong>
       <input
         type="date"
-        value="{{formatDate article post_date 'YYYY-MM-DD'}}"
+        value="{{formatDate article "post_date" "YYYY-MM-DD"}}"
         name="post_date"
       />
     </p>
@@ -39,14 +39,14 @@
       <strong>Most Recent Changes By</strong>
       <input
         type="text"
-        name="last_updated_by_name"
+        id="js-last-updated-by-name"
         value="{{article.last_updated_by.name}}"
         autocomplete="false"
         autocomplete="off"
       />
       <input
         type="hidden"
-        name="last_updated_by_user_id"
+        name="last_updated_by"
         value="{{article.last_updated_by.user_id}}"
       />
     </p>
@@ -54,7 +54,7 @@
       <strong>Most Recent Change</strong>
       <input
         type="date"
-        value="{{formatDate article updated_date 'YYYY-MM-DD'}}"
+        value="{{formatDate article "updated_date" "YYYY-MM-DD"}}"
         name="updated_date"
       />
     </p>


### PR DESCRIPTION
fixes: https://github.com/participedia/api/issues/507

sends admin only fields for updating author data as :
```
{
  creator: "390290", // user id
  post_date: "2017-12-29",
  last_updated_by: "417689", // user id
  updated_date: "2019-04-22"
}
```