### PR TITLE
case edit: don't edit has_components field 

### DIFF
--- a/views/case-edit.html
+++ b/views/case-edit.html
@@ -20,7 +20,6 @@
   </fieldset>
   <fieldset class="components fullonly">
     <h2 class="fieldset-header">{{t static "components_sectionlabel"}}</h2>
-    {{> edit-multi-select name="has_components" }}
     {{> article-edit-select name="is_component_of" }}
   </fieldset>
   <fieldset class="media">


### PR DESCRIPTION
`has_components` is read only and can only be set by other cases that edit `is_component_of`.

fixes: https://github.com/participedia/api/issues/505