### PR TITLE
map functionality updates

### DIFF
--- a/public/js/map.js
+++ b/public/js/map.js
@@ -1,5 +1,7 @@
+import moment from "moment";
 import mapStyle from "./map-style.js";
 import PopOver from "./GoogleMapsPopOver.js";
+import { xhrReq } from "./utils/utils.js";
 
 const markerIcon = {
   path: "M14.1,7.1C14.1,3.2,11,0,7.1,0S0,3.2,0,7.1C0,12.4,7.1,20,7.1,20S14.1,12.4,14.1,7.1z M4.7,7.1 c0-1.3,1.1-2.4,2.4-2.4s2.4,1.1,2.4,2.4s-1,2.4-2.4,2.4C5.8,9.4,4.7,8.4,4.7,7.1z",
@@ -18,6 +20,7 @@ const featuredMarkerIcon = Object.assign({}, markerIcon, {
 const map = {
   init() {
     const mapEl = document.querySelector(".js-map-container");
+    const isMethodTab = document.getElementById("method").checked;
 
     if (!mapEl) return;
 
@@ -31,7 +34,10 @@ const map = {
 
     this.initZoomControls(this.map);
 
-    this.renderMarkers();
+    if (!isMethodTab) {
+      // don't fetch results if we are on the methods tab
+      this.fetchMapResults();
+    }
   },
 
   initZoomControls(map) {
@@ -46,27 +52,98 @@ const map = {
     );
   },
 
-  renderMarkers() {
-    // markers are for cases and organizations, show no markers for methods
-    // red markers are featured articles, black for everything else
+  getQueryParam() {
+    if (!window.location.search) return;
 
-    const currentCardEls = document.querySelectorAll(
-      "[role='tabpanel']:not([hidden]) .js-cards-container li"
-    );
+    const paramObj = {};
+    window.location.search.split("?")[1].split("&").forEach(param => {
+     paramObj[param.split("=")[0]] = param.split("=")[1];
+    });
 
-    const markers = Array.prototype.slice.call(currentCardEls).map(el => {
-      const latLng = el.getAttribute("data-lat-lng");
+    return paramObj.query;
+  },
 
-      // if cards don't have lat,lng coords, don't render markers
-      if (!latLng) return;
+  fetchMapResults() {
+    let url = `/?resultType=map`;
+    const query = this.getQueryParam();
+    if (query) {
+      url = `${url}&query=${query}`;
+    }
 
-      const latitude = latLng.split(",")[0];
-      const longitude = latLng.split(",")[1];
+    const successCB = (response) => {
+      const results = JSON.parse(response.response).results;
+      this.cacheResults(response.responseURL, results);
+      this.renderMarkers(results);
+    };
+    const errorCB = (response) => {
+      //console.log("err", response)
+    };
+
+    const cachedResults = this.getCachedResults(window.location.origin + url);
+    if (cachedResults) {
+      // if we have cached results, render the markers with those
+      this.renderMarkers(cachedResults);
+    } else {
+      // if we don't have cached results, make the request
+      xhrReq("GET", url, {}, successCB, errorCB);
+    }
+  },
+
+  cacheResults(key, results) {
+    // save to session storage
+    const data = {
+      updatedAt: Date.now(),
+      results: results,
+    };
+    window.sessionStorage.setItem(key, JSON.stringify(data));
+  },
+
+  getCachedResults(key) {
+    const CACHE_TIMEOUT = Date.now() - 3600000; // 1 hour
+    const data = window.sessionStorage.getItem(key);
+
+    if(!data) return null;
+    const { updatedAt, results } = JSON.parse(data);
+    if (updatedAt < CACHE_TIMEOUT) {
+      return null;
+    } else {
+      return results;
+    }
+  },
+
+  filterResultsForTab(results) {
+    const currentTab = document.querySelector(".js-tab-container input:checked").id;
+
+    // return filtered results for cases and organizations, otherwise return all results
+    if (currentTab === "organizations") {
+      // NOTE: currentTab for organizations is plural, but article type is singular
+      return results.filter(article => article.type === "organization");
+    } else if (currentTab === "case"){
+      return results.filter(article => article.type === "case");
+    } else {
+      return results;
+    }
+  },
+
+  renderMarkers(results) {
+    const articleCardsContainer = document.querySelector(".js-cards-container");
+    const filteredResults = this.filterResultsForTab(results);
+
+    const markers = filteredResults.map(article => {
+      const { latitude, longitude } = article;
+
+      // if article doesn't have lat,lng coords, don't render markers
+      if (!latitude || !longitude) return;
 
       return {
-        featured: el.getAttribute("data-featured"),
+        id: article.id,
+        type: article.type,
+        photo: article.photos && article.photos[0].url,
+        submittedDate: article.updated_date,
+        title: article.title,
+        featured: article.featured,
         position: new google.maps.LatLng(latitude, longitude),
-        content: el,
+        content: articleCardsContainer.querySelector("li"),
       };
     });
 
@@ -75,7 +152,7 @@ const map = {
       const markerEl = new google.maps.Marker({
         position: marker.position,
         map: this.map,
-        icon: marker.featured === "true" ? featuredMarkerIcon : markerIcon,
+        icon: marker.featured === true ? featuredMarkerIcon : markerIcon,
       });
 
       // on marker click, show article card in popover on map
@@ -85,9 +162,33 @@ const map = {
         popOverContentEl.classList = "article-card";
         popOverContentEl.innerHTML = marker.content.innerHTML;
 
-        // truncate article title to 45 chars
+        // update type
+        const articleTypeEl = popOverContentEl.querySelector(".article-card-meta h5");
+        articleTypeEl.innerHTML = marker.content.getAttribute("data-i18n-type");
+
+        // update image
+        const articleImageEl = popOverContentEl.querySelector(".article-card-img");
+        articleImageEl.style.backgroundImage = `url("${marker.photo}")`;
+
+        // update title & truncate to 45 chars
         const articleTitleEl = popOverContentEl.querySelector(".article-card-title");
-        articleTitleEl.innerText = articleTitleEl.innerText.substring(0, 45) + "...";
+        if (marker.title.length < 46) {
+          articleTitleEl.innerText = marker.title;
+        } else {
+          articleTitleEl.innerText = marker.title.substring(0, 45) + "...";
+        }
+
+        // update submitted at
+        const articleSubmittedDate = popOverContentEl.querySelector(".js-article-date");
+        articleSubmittedDate.innerHtml = moment(marker.submittedDate).format("MMMM M, YYYY");
+
+        // update links
+        const articleLinks = Array.prototype.slice.call(
+          popOverContentEl.querySelectorAll(".js-article-link")
+        );
+        articleLinks.forEach(el => {
+          el.setAttribute("href", `/${marker.type}/${marker.id}`);
+        });
 
         // if there is already a current pop over, remove it
         if (this.popOver) {

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -99,7 +99,7 @@ const map = {
   },
 
   getCachedResults(key) {
-    const CACHE_TIMEOUT = Date.now() - 3600000; // 1 hour
+    const CACHE_TIMEOUT = Date.now() - 300000; // 5mins === 300000ms
     const data = window.sessionStorage.getItem(key);
 
     if(!data) return null;

--- a/views/partials/article-card.html
+++ b/views/partials/article-card.html
@@ -1,11 +1,9 @@
 <li
   class="article-card"
-  data-featured="{{featured}}"
-  {{#if latitude}}
-    data-lat-lng="{{latitude}}, {{longitude}}"
-  {{/if}}
+  data-type="{{type}}"
+  data-i18n-type="{{toUpperCase (t type)}}"
 >
-  <a href="/{{type}}/{{id}}">
+  <a href="/{{type}}/{{id}}" class="js-article-link">
     <div
       class="article-card-img"
       style="background-image: url('{{getFirstImageForArticle this}}')"
@@ -19,7 +17,10 @@
         {{#if description}}
           <p class="article-card-description">{{description}}</p>
         {{/if}}
-        <p class="small">{{t "Submitted"}} {{formatDate this "updated_date" "MMMM M, YYYY"}}</p>
+        <p class="small">
+          {{t "Submitted"}}
+          <span class="js-article-date">{{formatDate this "updated_date" "MMMM M, YYYY"}}</span>
+        </p>
       </div>
       <a
         href="#"


### PR DESCRIPTION
https://github.com/participedia/api/issues/530

- on all tab: show all cases and orgs with black pins. show featured articles with red pins
- on cases and orgs tabs: show all cases or orgs depending on tab with black pins, show featured with red pins
- methods tab shows no pins
- if there is a search term, map only shows results of search with black pins, and shows featured articles in red pins
- use /search?resultType=map endpoint to get map results

in this gif you can see the initial pageload with an empty cache renders the pins a bit slowly, but all other tabs render the pins quickly because the results have been cached from the first request. i set the cache timeout for 1 hour. @dethe, @jesicarson does this seem like a reasonable time frame? should it be shorter?

![particpedia-map-changes](https://user-images.githubusercontent.com/130878/57340161-82766980-70e9-11e9-9309-0e57cf4c1aca.gif)
