### PR TITLE
Cache slow queries

### DIFF
--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -314,28 +314,11 @@ async function getEditStaticText(params) {
 
 async function getCaseEditHttp(req, res) {
   let startTime = new Date();
-  console.warn("start getCaseEditHttp");
   const params = parseGetParams(req, "case");
-  console.warn(
-    "Elapsed after parseGetParams(): %s",
-    (new Date() - startTime) / 1000 + "s"
-  );
   params.view = "edit";
   const article = await getCase(params);
-  console.warn(
-    "Elapsed after getCase(): %s",
-    (new Date() - startTime) / 1000 + "s"
-  );
   const staticText = await getEditStaticText(params);
-  console.warn(
-    "Elapsed after getEditStaticText(): %s",
-    (new Date() - startTime) / 1000 + "s"
-  );
   returnByType(res, params, article, staticText, req.user);
-  console.warn(
-    "end getCaseEditHttp, elapsed: %s",
-    (new Date() - startTime) / 1000 + "s"
-  );
 }
 
 async function getCaseNewHttp(req, res) {

--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -18,6 +18,7 @@ const {
   listCases,
   listMethods,
   listOrganizations,
+  refreshSearch,
   ErrorReporter
 } = require("../helpers/db");
 
@@ -248,7 +249,7 @@ async function postCaseUpdateHttp(req, res) {
       OK: true,
       article: freshArticle
     });
-    db.none("REFRESH MATERIALIZED VIEW search_index_en;");
+    refreshSearch();
   } else {
     console.error("Reporting errors: %s", er.errors);
     res.status(400).json({
@@ -303,10 +304,10 @@ async function getEditStaticText(params) {
   const lang = params.lang;
   let staticText = Object.assign({}, sharedFieldOptions);
 
-  staticText.authors = await listUsers();
-  staticText.cases = await listCases(lang);
-  staticText.methods = await listMethods(lang);
-  staticText.organizations = await listOrganizations(lang);
+  staticText.authors = listUsers();
+  staticText.cases = listCases(lang);
+  staticText.methods = listMethods(lang);
+  staticText.organizations = listOrganizations(lang);
 
   return staticText;
 }

--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -312,11 +312,29 @@ async function getEditStaticText(params) {
 }
 
 async function getCaseEditHttp(req, res) {
+  let startTime = new Date();
+  console.warn("start getCaseEditHttp");
   const params = parseGetParams(req, "case");
+  console.warn(
+    "Elapsed after parseGetParams(): %s",
+    (new Date() - startTime) / 1000 + "s"
+  );
   params.view = "edit";
   const article = await getCase(params);
+  console.warn(
+    "Elapsed after getCase(): %s",
+    (new Date() - startTime) / 1000 + "s"
+  );
   const staticText = await getEditStaticText(params);
+  console.warn(
+    "Elapsed after getEditStaticText(): %s",
+    (new Date() - startTime) / 1000 + "s"
+  );
   returnByType(res, params, article, staticText, req.user);
+  console.warn(
+    "end getCaseEditHttp, elapsed: %s",
+    (new Date() - startTime) / 1000 + "s"
+  );
 }
 
 async function getCaseNewHttp(req, res) {

--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -14,6 +14,7 @@ const {
   INSERT_LOCALIZED_TEXT,
   UPDATE_METHOD,
   listUsers,
+  refreshSearch,
   ErrorReporter
 } = require("../helpers/db");
 
@@ -36,7 +37,7 @@ const sharedFieldOptions = require("../helpers/shared-field-options.js");
 async function getEditStaticText(params) {
   let staticText = {};
   try {
-    staticText.authors = await listUsers();
+    staticText.authors = listUsers();
   } catch (e) {
     console.error("Error reading users");
   }
@@ -186,7 +187,7 @@ async function postMethodUpdateHttp(req, res) {
       OK: true,
       article: freshArticle
     });
-    db.none("REFRESH MATERIALIZED VIEW search_index_en;");
+    refreshSearch();
   } else {
     console.error("Reporting errors: %s", er.errors);
     res.status(400).json({

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -14,6 +14,7 @@ const {
   INSERT_LOCALIZED_TEXT,
   UPDATE_ORGANIZATION,
   listUsers,
+  refreshSearch,
   listMethods,
   ErrorReporter
 } = require("../helpers/db");
@@ -37,8 +38,8 @@ async function getEditStaticText(params) {
   let staticText = {};
   const lang = params.lang;
 
-  staticText.authors = await listUsers();
-  staticText.methods = await listMethods(lang);
+  staticText.authors = listUsers();
+  staticText.methods = listMethods(lang);
 
   staticText = Object.assign({}, staticText, sharedFieldOptions);
 
@@ -169,7 +170,7 @@ async function postOrganizationUpdateHttp(req, res) {
       OK: true,
       article: freshArticle
     });
-    db.none("REFRESH MATERIALIZED VIEW search_index_en;");
+    refreshSearch();
   } else {
     console.error("Reporting errors: %s", er.errors);
     res.status(400).json({


### PR DESCRIPTION
Lists of users, cases, methods, and organizations returned as part of edit api are cached for a random time (between 3 and 8 minutes) to avoid making those api calls so slow that they time out. Instead of taking over 3 seconds for the edit case call, it now takes about 25 milliseconds.

Also changed how updating the search works. When changes are made to the searchable data, instead of reindexing all the text (very slow) during that request, we simply mark a flag that the search needs to be reindexed. Every 3-8 minutes (same timeout as above) we check that flag, and if it is set we clear it and reindex the search. So the system will be slow to respond occasionally, but will not be slowed on every single edit.