### PR TITLE
553 missing fields

### DIFF
--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -214,10 +214,9 @@ function getUpdatedMethod(user, params, newMethod, oldMethod) {
   ["links", "videos", "audio"].map(key => cond(key, as.media));
   // photos and files are slightly different from other media as they have a source url too
   ["photos", "files"].map(key => cond(key, as.sourcedMedia));
-  // boolean (would include "published" but we don't really support it)
-  ["facilitators"].map(key => cond(key, as.yesno));
   // key
   [
+    "facilitators",
     "facetoface_online_or_both",
     "public_spectrum",
     "open_limited",
@@ -233,7 +232,8 @@ function getUpdatedMethod(user, params, newMethod, oldMethod) {
     "number_of_participants",
     "decision_methods",
     "if_voting",
-    "number_of_participants"
+    "number_of_participants",
+    "purpose_method"
   ].map(key => cond(key, as.methodkeys));
   // TODO save bookmarked on user
   return [updatedMethod, er];

--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -246,6 +246,9 @@ function id(string, field) {
 // as.ids, strip [{text,value}] down to [value], then format as array of numbers
 function ids(idList) {
   if (!idList) return [];
+  if (idList.length && isObject(idList[0])) {
+    return idList.map(item => parseInt(item.id, 10));
+  }
   return idList;
   // return idList.map(item => parseInt(item.key, 10));
 }

--- a/api/sql/method_by_id.sql
+++ b/api/sql/method_by_id.sql
@@ -23,11 +23,13 @@ WITH full_thing AS (
     links,
     audio,
     -- key values
+    facilitators,
     facetoface_online_or_both,
     public_spectrum,
     open_limited,
     recruitment_method,
     level_polarization,
+    level_complexity,
     -- key lists
     method_types,
     number_of_participants,
@@ -35,8 +37,7 @@ WITH full_thing AS (
     participants_interactions,
     decision_methods,
     if_voting,
-    -- yesno
-    facilitators
+    purpose_method,
 FROM
     methods,
     get_localized_texts(${articleid}, ${lang}) AS texts

--- a/api/sql/method_by_id.sql
+++ b/api/sql/method_by_id.sql
@@ -37,7 +37,7 @@ WITH full_thing AS (
     participants_interactions,
     decision_methods,
     if_voting,
-    purpose_method,
+    purpose_method
 FROM
     methods,
     get_localized_texts(${articleid}, ${lang}) AS texts

--- a/api/sql/update_method.sql
+++ b/api/sql/update_method.sql
@@ -13,21 +13,22 @@ SET
   videos = ${videos},
   audio = ${audio},
   photos = ${photos},
--- yesno
-  facilitators = ${facilitators},
 -- keys
+  facilitators = ${facilitators},
   facetoface_online_or_both = ${facetoface_online_or_both},
   public_spectrum = ${public_spectrum},
   open_limited = ${open_limited},
   recruitment_method = ${recruitment_method},
   level_polarization = ${level_polarization},
+  level_complexity = ${level_complexity},
 -- list of keys
   method_types = ${method_types},
   number_of_participants = ${number_of_participants},
   scope_of_influence = ${scope_of_influence},
   participants_interactions = ${participants_interactions},
   decision_methods = ${decision_methods},
-  if_voting = ${if_voting}
+  if_voting = ${if_voting},
+  purpose_method = ${purpose_method}
 WHERE
   id = ${id}
 ;

--- a/migrations/migration_039.sql
+++ b/migrations/migration_039.sql
@@ -1,0 +1,2 @@
+ALTER TABLE methods ADD COLUMN level_complexity TEXT default '';
+ALTER TABLE methods ADD COLUMN purpose_method TEXT[] default '{}';

--- a/test/cases.js
+++ b/test/cases.js
@@ -37,12 +37,11 @@ describe("Cases", () => {
       await postCaseNewHttp(req, res);
       ret.body.OK.should.be.false;
     });
-    it.only("works with authentication", async () => {
+    it("works with authentication", async () => {
       const body = await addBasicCase();
       body.OK.should.be.true;
       let returnedCase = body.article;
       returnedCase.id.should.be.a("number");
-      returnedCase.videos.length.should.equal(2);
       returnedCase.creator.user_id.should.equal(
         returnedCase.last_updated_by.user_id
       );

--- a/test/cases.js
+++ b/test/cases.js
@@ -166,14 +166,21 @@ describe("Cases", () => {
       const body1 = await addBasicCase();
       body1.OK.should.be.true;
       const case1 = body1.article;
-      case1.photos.length.should.equal(4);
+      case1.photos.length.should.equal(3);
       case1.photos[0].url.should.equal(
         "https://s3.amazonaws.com/uploads.participedia.xyz/index.php__21.jpg"
       );
       const { req, res, ret } = getMocksAuth({
         params: { thingid: case1.id },
         body: {
-          photos: [{ url: "http://foobar.com/test.jpg" }]
+          photos: [
+            {
+              url: "http://foobar.com/test.jpg",
+              source_url: "https://example.com/foobar",
+              title: "Right ho!",
+              attribution: "Marie Osmond"
+            }
+          ]
         }
       });
       await postCaseUpdateHttp(req, res);

--- a/test/data/method.json
+++ b/test/data/method.json
@@ -9,34 +9,60 @@
   "title": "First Title",
   "description": "First Description",
   "body": "First Body",
-  "files": [],
+  "files": [
+    {
+      "url": "https://example.com/firstfile.pdf",
+      "source_url": "https://example.com/firstsource/",
+      "title": "My first file",
+      "attribution": "Atilla the Hun"
+    },
+    {
+      "url": "https://example.com/secondfile.xml",
+      "source_url": "https://example.com/secondsource/",
+      "title": "My second file",
+      "attribution": "Jane Goodall"
+    }
+  ],
   "links": [
     {
       "url": "https://killsixbilliondemons.com",
-      "title": "",
-      "attribution": ""
+      "title": "Kill Six Billion Demons",
+      "attribution": "Abbaddon"
     }
   ],
-  "videos": [],
+  "videos": [
+    {
+      "url": "https://youtube.com/xrbrbl",
+      "title": "Naked mole rats",
+      "attribution": "The primitive skills channel"
+    }
+  ],
   "photos": [
     {
       "url": "http://example.com/picture.jpg",
-      "source_url": "",
+      "source_url": "https://stockphoto.com/",
       "title": "generic photo",
       "attribution": "anonymous"
     }
   ],
-  "audio": [],
+  "audio": [
+    {
+      "url": "http://example.com/firstvoice.au",
+      "title": "Come here Watson, I need you.",
+      "attribution": "Johans Kessler"
+    }
+  ],
   "facilitators": "no",
   "facetoface_online_or_both": "both",
-  "public_spectrum": "",
-  "open_limited": "",
-  "recruitment_method": "",
-  "level_polarization": "",
-  "scope_of_influence": [],
-  "method_types": [],
-  "number_of_participants": [],
-  "participants_interactions": [],
-  "decision_methods": [],
-  "if_voting": []
+  "public_spectrum": "inform",
+  "open_limited": "open_to",
+  "recruitment_method": "random",
+  "level_polarization": "moderate",
+  "level_complexity": "moderate",
+  "scope_of_influence": ["organization", "national"],
+  "method_types": ["collaborative", "direct"],
+  "number_of_participants": ["no_limit"],
+  "participants_interactions": ["discussion", "informal"],
+  "decision_methods": ["idea", "voting"],
+  "if_voting": ["preferential", "unanimous"]
 }

--- a/test/data/method.json
+++ b/test/data/method.json
@@ -64,5 +64,6 @@
   "number_of_participants": ["no_limit"],
   "participants_interactions": ["discussion", "informal"],
   "decision_methods": ["idea", "voting"],
-  "if_voting": ["preferential", "unanimous"]
+  "if_voting": ["preferential", "unanimous"],
+  "purpose_method": ["develop", "academic"]
 }

--- a/test/data/organization.json
+++ b/test/data/organization.json
@@ -19,7 +19,7 @@
   ],
   "links": [
     {
-      "url": "https://killsixbilliondemons.com",
+      "url": "https://killsixbilliondemons.com/",
       "title": "",
       "attribution": ""
     }

--- a/test/data/organization.json
+++ b/test/data/organization.json
@@ -9,7 +9,14 @@
   "title": "First Title",
   "description": "First Description",
   "body": "First Body",
-  "files": [],
+  "files": [
+    {
+      "url": "https://example.com/fileuno.txt",
+      "title": "Evan tempted by the apple",
+      "source_url": "http://example.com/mouser",
+      "attribution": "Bonnie and Clyde"
+    }
+  ],
   "links": [
     {
       "url": "https://killsixbilliondemons.com",
@@ -26,20 +33,26 @@
       "attribution": "anonymous"
     }
   ],
-  "audio": [],
-  "location_name": "",
-  "address1": "",
+  "audio": [
+    {
+      "url": "http://livingcode.org/soundgarden",
+      "title": "That song you almost know the words to",
+      "attribution": "Chairman Mao"
+    }
+  ],
+  "location_name": "Hooter's",
+  "address1": "1234 Court Hill Rd.",
   "address2": "",
-  "city": "",
-  "province": "",
-  "postal_code": "",
-  "latitude": 0,
-  "longitude": 0,
-  "sector": "",
-  "scope_of_influence": [],
-  "type_method": [],
-  "type_tool": [],
-  "specific_topics": [],
-  "general_issues": [],
-  "specific_methods_tools_techniques": []
+  "city": "Columbus",
+  "province": "OH",
+  "postal_code": "45710",
+  "latitude": 42.6,
+  "longitude": 85.2,
+  "sector": "higher_ed",
+  "scope_of_influence": ["city/town"],
+  "type_method": ["collaborative", "direct"],
+  "type_tool": ["manage", "facilitate"],
+  "specific_topics": ["addiction", "affordable"],
+  "general_issues": ["energy", "human"],
+  "specific_methods_tools_techniques": [190, 191]
 }

--- a/test/methods.js
+++ b/test/methods.js
@@ -45,8 +45,62 @@ describe("Methods", () => {
       body.OK.should.be.true;
       const article = body.article;
       article.id.should.be.a("number");
-      article.links.should.have.lengthOf(1);
-      article.links[0].url.should.equal("https://killsixbilliondemons.com/");
+      article.creator.user_id.should.equal(article.last_updated_by.user_id);
+      // test key fields
+      [
+        "facilitators",
+        "facetoface_online_or_both",
+        "public_spectrum",
+        "open_limited",
+        "recruitment_method",
+        "level_polarization",
+        "level_complexity"
+      ].forEach(key => {
+        expect(
+          article[key],
+          `expected ${key} to equal "${example_method[key]}", but got "${
+            article[key]
+          }"`
+        ).to.equal(example_method[key]);
+      });
+      // test key list fields
+      [
+        "method_types",
+        "scope_of_influence",
+        "participants_interactions",
+        "number_of_participants",
+        "decision_methods",
+        "if_voting",
+        "number_of_participants",
+        "purpose_method"
+      ].forEach(key => {
+        let ret = article[key];
+        let exp = example_method[key];
+        ret.length.should.equal(exp.length);
+        for (var i = 0; i < ret.length; i++) {
+          expect(ret[i], `for key ${key} and index ${i}`).to.equal(exp[i]);
+        }
+      });
+      // test media fields
+      ["files", "links", "videos", "audio", "photos"].forEach(key => {
+        article[key].length.should.equal(example_method[key].length);
+        for (let i = 0; i < article[key].length; i++) {
+          let ret = article[key][i];
+          let exp = example_method[key][i];
+          expect(ret.attribution, `for key ${key} and index ${i}`).to.equal(
+            exp.attribution
+          );
+          expect(ret.title, `for key ${key} and index ${i}`).to.equal(
+            exp.title
+          );
+          expect(ret.url, `for key ${key} and index ${i}`).to.equal(exp.url);
+          if (exp.source_url) {
+            expect(ret.source_url, `for key ${key} and index ${i}`).to.equal(
+              exp.source_url
+            );
+          }
+        }
+      });
     });
   });
   describe("Test edit API", () => {

--- a/test/methods.js
+++ b/test/methods.js
@@ -133,7 +133,14 @@ describe("Methods", () => {
       const method1 = body1.article;
       method1.photos[0].url.should.equal("http://example.com/picture.jpg");
       const body2 = await updateMethod(method1.id, {
-        photos: [{ url: "http://garfield.com/jon.png" }]
+        photos: [
+          {
+            url: "http://garfield.com/jon.png",
+            source_url: "https://example.com/garfields_tomb",
+            title: "Jon lays a wreath",
+            attribution: "Cleveland Plain Dealer"
+          }
+        ]
       });
       body2.OK.should.be.true;
       should.exist(body2.article);
@@ -142,7 +149,12 @@ describe("Methods", () => {
       expect(method2.updated_date > method1.updated_date).to.be.true;
       const photos = [method1.photos[0]];
       photos.push(method2.photos[0]);
-      photos.push({ url: "https://wonderwall.com/howzaboutthemjpegs.png" });
+      photos.push({
+        url: "https://wonderwall.com/howzaboutthemjpegs.png",
+        source_url: "https://example.com/ugh",
+        attribution: "The Red Menace",
+        title: "Whatever"
+      });
       const body3 = await updateMethod(method1.id, { photos: photos });
       body3.OK.should.be.true;
       const method3 = body3.article;
@@ -153,8 +165,16 @@ describe("Methods", () => {
     it("Add method, then change links", async () => {
       const method1 = (await addBasicMethod()).article;
       const links = [
-        { url: "https://xkcd.com/" },
-        { url: "http://girlgeniusonline.com/" }
+        {
+          url: "https://xkcd.com/",
+          title: "xkcd",
+          attribution: "Randall Monroe"
+        },
+        {
+          url: "http://girlgeniusonline.com/",
+          title: "Girl Genius",
+          attribution: "Professors Foglio"
+        }
       ];
       const method2 = (await updateMethod(method1.id, {
         title: "Second Title",

--- a/test/organizations.js
+++ b/test/organizations.js
@@ -76,7 +76,14 @@ describe("Organizations", () => {
         "http://example.com/picture.jpg"
       );
       const body2 = await updateOrganization(organization1.id, {
-        photos: [{ url: "http://garfield.com/jon.png" }]
+        photos: [
+          {
+            url: "http://garfield.com/jon.png",
+            source_url: "https://example.com/obligatory_plug",
+            title: "In Ned Flanders Field",
+            attribution: "Birt Sampson"
+          }
+        ]
       });
       body2.OK.should.be.true;
       const organization2 = body2.article;


### PR DESCRIPTION
* Added much more complete tests for methods and organizations
* Added two missing method properties
* Applied changes to tests that broke because media objects are now working properly

Requires `npm run migratelocal 39` which I have already applied to the staging server.

Fixes #553 