### PR TITLE
add 404 handling, respond with 404 if article hidden for non admins

### DIFF
--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -46,6 +46,12 @@ const fixUpURLs = function(article) {
 
 const returnByType = (res, params, article, static, user) => {
   const { returns, type, view } = params;
+
+  // if article is hidden and user is not admin, return 404
+  if (article.hidden && (!user || (user && !user.isadmin))) {
+    return res.status(404).render("404");
+  }
+
   switch (returns) {
     case "htmlfrag":
       return res.status(200).render(type + "-" + view, {

--- a/app.js
+++ b/app.js
@@ -210,4 +210,11 @@ app.get("/content-chooser", function(req, res) {
   res.status(200).render("content-chooser");
 });
 
+
+// 404 error handling
+// this should always be after all routes to catch all invalid urls
+app.use((req, res, next) => {
+  res.status(404).render("404");
+});
+
 module.exports = app;

--- a/locales/en.js
+++ b/locales/en.js
@@ -1353,5 +1353,6 @@
   "case_edit_featured_instructional": "Featured articles are displayed first on the home page",
   "case_edit_hidden_label": "Hidden",
   "case_edit_hidden_instructional": "Hidden articles will not show up in search results",
-  "Admin Only": "Admin Only"
+  "Admin Only": "Admin Only",
+  "404_error_msg": "Sorry, this page doesn't exist"
 }

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -243,3 +243,14 @@ pre {
   align-items: center;
   height: 200px;
 }
+
+.error-404-container {
+  /* viewport height minus header/footer */
+  height: calc(100VH - 316px);
+}
+.error-404-content {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+}

--- a/views/404.html
+++ b/views/404.html
@@ -1,0 +1,5 @@
+<div class="error-404-container">
+  <div class="error-404-content">
+    <h2>{{t "404_error_msg"}}</h2>
+  </div>
+</div>


### PR DESCRIPTION
adds handling to respond with a 404 page for invalid urls and hidden articles (for non admins)

<img width="1280" alt="Screenshot 2019-05-23 12 24 12" src="https://user-images.githubusercontent.com/130878/58280659-04a39680-7d56-11e9-8ed6-2ed85ece5fbf.png">

fixes https://github.com/participedia/api/issues/616

@jesicarson @dethe @scottofletcher 