### PR TITLE
fix evaluation_reports bug

### DIFF
--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -398,11 +398,12 @@ function aSourcedMedia(obj) {
   }
   if (!obj.url) return null;
 
-  // if url is not already an amazon url, upload the file
-  let url = obj.url;
-  // some types of sourced media are links, anything already a link does not need to be uploaded
-  if (!obj.url.startsWith("http")) {
+  // if the url string is a data uri, upload to aws
+  // otherwise it's already been uploaded and doesn't start with http, add the aws url base
+  if (obj.url.startsWith("data:")) {
     obj.url = uploadToAWS(obj.url, obj.title);
+  } else if (!obj.url.startsWith("http")) {
+    obj.url = process.env.AWS_UPLOADS_URL + obj.url;
   }
   return new FullFile(obj);
 }


### PR DESCRIPTION
some `evaluation_reports` urls that were uploaded with the old xyz ui were not saved with the aws base url. this was causing an error because our file upload code was only expecting to see either a data uri or a url that starts with http.

with this change the file upload function with check that the string is a data uri before uploading. if it's not a data uri and it's not already an aws url, add the aws base url.

fixes: https://github.com/participedia/usersnaps/issues/722