### PR TITLE
updates the "Do Full Version" flow

### DIFF
--- a/public/js/edit-form.js
+++ b/public/js/edit-form.js
@@ -108,7 +108,7 @@ const editForm = {
     if (response.user) {
       // redirect to user profile page
       location.href = `/user/${response.user.id}`;
-    } else {
+    } else if (response.article) {
       // redirect to article reader page
       location.href = `/${response.article.type}/${response.article.id}`;
     }

--- a/public/js/edit-form.js
+++ b/public/js/edit-form.js
@@ -33,7 +33,8 @@ const editForm = {
       .addEventListener("click", e => {
         e.preventDefault();
         const articleEl = document.querySelector("[data-submit-type]");
-        const type = articleEl.setAttribute("data-submit-type", "full");
+        // change submit type attribute
+        articleEl.setAttribute("data-submit-type", "full");
         // update url param
         history.pushState({}, document.title, `${window.location.href}?full=1`);
         // scroll to top

--- a/public/js/edit-warning.js
+++ b/public/js/edit-warning.js
@@ -10,9 +10,10 @@ const editWarning = {
 
     window.addEventListener("beforeunload", (e) => {
       // when the form is submitted we set a flag, if it's a submit click, we don't want to show the warning
-      const isSubmitClick = sessionStorage.getItem("submitButtonClick") === "true";
+      const isSubmitClick = sessionStorage.getItem("participedia:submitButtonClick") === "true";
+      const hasBeenSaved = sessionStorage.getItem("participedia:hasBeenSaved") === "true";
 
-      if (!isSubmitClick) {
+      if (!isSubmitClick && !hasBeenSaved) {
         const currentFormData = serialize(formEl);
         // check if form data changed and if it was show default confirmation dialog
         if (initialFormData !== currentFormData) {
@@ -21,9 +22,11 @@ const editWarning = {
           return "";              // Gecko and WebKit
         }
       } else {
-        // it was a submit click, so we can reset the flag before the request continues
+        // it was a submit click or it's already been saved,
+        // so we can reset the flags before the request continues
         try {
-          window.sessionStorage.setItem("submitButtonClick", "false");
+          window.sessionStorage.setItem("participedia:submitButtonClick", "false");
+          window.sessionStorage.setItem("participedia:hasBeenSaved", "false");
         } catch (err) {
           console.warn(err);
         }

--- a/public/js/edit-warning.js
+++ b/public/js/edit-warning.js
@@ -10,10 +10,9 @@ const editWarning = {
 
     window.addEventListener("beforeunload", (e) => {
       // when the form is submitted we set a flag, if it's a submit click, we don't want to show the warning
-      const isSubmitClick = sessionStorage.getItem("participedia:submitButtonClick") === "true";
-      const hasBeenSaved = sessionStorage.getItem("participedia:hasBeenSaved") === "true";
+      const isSubmitClick = sessionStorage.getItem("submitButtonClick") === "true";
 
-      if (!isSubmitClick && !hasBeenSaved) {
+      if (!isSubmitClick) {
         const currentFormData = serialize(formEl);
         // check if form data changed and if it was show default confirmation dialog
         if (initialFormData !== currentFormData) {
@@ -22,11 +21,9 @@ const editWarning = {
           return "";              // Gecko and WebKit
         }
       } else {
-        // it was a submit click or it's already been saved,
-        // so we can reset the flags before the request continues
+        // it was a submit click, so we can reset the flag before the request continues
         try {
-          window.sessionStorage.setItem("participedia:submitButtonClick", "false");
-          window.sessionStorage.setItem("participedia:hasBeenSaved", "false");
+          window.sessionStorage.setItem("submitButtonClick", "false");
         } catch (err) {
           console.warn(err);
         }

--- a/views/partials/edit-form.html
+++ b/views/partials/edit-form.html
@@ -39,7 +39,7 @@
         {{> icon-submit }} {{t "Publish"}}
       </button>
 
-      <a href="?full=1" class="button button-dark-grey quickonly">{{t "Do Full Version"}}</a>
+      <a href="?full=1" class="button button-dark-grey quickonly js-do-full-version">{{t "Do Full Version"}}</a>
     </div>
 
     <div class="something-missing-prompt">


### PR DESCRIPTION
Updates the "Do Full Version" flow, so we show the full version fields without saving the current changes or discarding them.

![participedia-do-full-version-flow-2](https://user-images.githubusercontent.com/130878/58740878-2fca5d80-83c8-11e9-8312-d0982dbac837.gif)

fixes: https://github.com/participedia/usersnaps/issues/651

@jesicarson 
