### PR TITLE
allow admins to hide/unhide methods and orgs

### DIFF
--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -246,7 +246,7 @@ async function getMethodHttp(req, res) {
   const article = articleRow.results;
   fixUpURLs(article);
   const staticText = {};
-  returnByType(res, params, article, staticText);
+  returnByType(res, params, article, staticText, req.user);
 }
 
 async function getMethodEditHttp(req, res) {
@@ -256,7 +256,7 @@ async function getMethodEditHttp(req, res) {
   const article = articleRow.results;
   fixUpURLs(article);
   const staticText = await getEditStaticText(params);
-  returnByType(res, params, article, staticText);
+  returnByType(res, params, article, staticText, req.user);
 }
 
 async function getMethodNewHttp(req, res) {

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -237,7 +237,7 @@ async function getOrganizationHttp(req, res) {
   const article = articleRow.results;
   fixUpURLs(article);
   const staticText = {};
-  returnByType(res, params, article, staticText);
+  returnByType(res, params, article, staticText, req.user);
 }
 
 async function getOrganizationEditHttp(req, res) {
@@ -247,7 +247,7 @@ async function getOrganizationEditHttp(req, res) {
   const article = articleRow.results;
   fixUpURLs(article);
   const staticText = await getEditStaticText(params);
-  returnByType(res, params, article, staticText);
+  returnByType(res, params, article, staticText, req.user);
 }
 
 async function getOrganizationNewHttp(req, res) {


### PR DESCRIPTION
- needed to pass user obj to `returnByType` for methods and orgs
fixes: https://github.com/participedia/usersnaps/issues/732