### PR TITLE
explicitly request json for the map results

### DIFF
--- a/public/js/map.js
+++ b/public/js/map.js
@@ -95,7 +95,7 @@ const map = {
   },
 
   fetchMapResults() {
-    let url = `/?resultType=map`;
+    let url = `/?resultType=map&returns=json`;
     const query = this.getQueryParam();
     if (query) {
       url = `${url}&query=${query}`;


### PR DESCRIPTION
this bug was introduced with this change: https://github.com/participedia/api/pull/642
we now need to explicitly request json for the map results.

fixes: https://github.com/participedia/usersnaps/issues/735