### PR TITLE
fix column gaps on older safari

### DIFF
--- a/public/css/tabs-with-cards.css
+++ b/public/css/tabs-with-cards.css
@@ -44,6 +44,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
   column-gap: 30px;
+  grid-column-gap: 30px;
 }
 
 .article-card {


### PR DESCRIPTION
before:
<img width="667" alt="Screenshot 2019-06-11 12 01 34" src="https://user-images.githubusercontent.com/130878/59266886-ba208600-8c40-11e9-910b-959179c1b39d.png">

after:
<img width="679" alt="Screenshot 2019-06-11 12 01 22" src="https://user-images.githubusercontent.com/130878/59266881-b856c280-8c40-11e9-8f98-ebf2af47fe0f.png">

@jesicarson 
