### PR TITLE
move google/maps dependency to prod dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -365,7 +365,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@google/maps/-/maps-0.5.5.tgz",
       "integrity": "sha512-RSZriyE2XViVhXgdEcQaEu3jMYh2A/jS0VahLHXqGO0VfPyEbDac4PAn7/hBJiTavWpxchKfe5OI9inJofFWxA==",
-      "dev": true,
       "requires": {
         "uuid": ">=2.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node": "11.2.0"
   },
   "dependencies": {
+    "@google/maps": "0.5.5",
     "apicache": "^1.1.1",
     "async": "^2.3.0",
     "autocompleter": "^4.0.2",
@@ -57,7 +58,6 @@
     "winston": "^2.3.1"
   },
   "devDependencies": {
-    "@google/maps": "0.5.5",
     "auth0": "^2.14.0",
     "auth0-js": "^9.9.0",
     "auth0-lock": "^11.13.0",


### PR DESCRIPTION
Need to move the google/maps dependency to prod dependencies so I can run this script https://github.com/participedia/api/blob/master/scripts/geocode-address-for-lat-lng.js#L11 on prod.