### PR TITLE
handle csv download for cases, methods and orgs tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ public/build/js/*
 
 # Editor files
 .vscode
+
+#csv data dump files
+public/participedia-data-cases.csv
+public/participedia-data-methods.csv
+public/participedia-data-organizations.csv

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -258,21 +258,11 @@ router.get("/", async function(req, res) {
           user: req.user || null
         });
       case "csv":
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> f90081e... handle case when on all tab
         if (type === "thing") {
           return res.status(200).json({
             msg: "You can only get a csv file from cases, methods or organizations tabs."
           });
         } else {
-<<<<<<< HEAD
-=======
-        if (type !== "thing") {
->>>>>>> edadbf0... make it work for all article types
-=======
->>>>>>> f90081e... handle case when on all tab
           const file = await createCSVDataDump(type);
           return res.download(file);
         }

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -15,6 +15,7 @@ let {
 let { preparse_query } = require("../helpers/search");
 let log = require("winston");
 const { supportedTypes, parseGetParams } = require("../helpers/things");
+const createCSVDataDump = require("../helpers/create-csv-data-dump.js");
 
 const RESPONSE_LIMIT = 20;
 
@@ -257,7 +258,24 @@ router.get("/", async function(req, res) {
           user: req.user || null
         });
       case "csv":
-        return res.status(500, "CSV not implemented yet").render();
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> f90081e... handle case when on all tab
+        if (type === "thing") {
+          return res.status(200).json({
+            msg: "You can only get a csv file from cases, methods or organizations tabs."
+          });
+        } else {
+<<<<<<< HEAD
+=======
+        if (type !== "thing") {
+>>>>>>> edadbf0... make it work for all article types
+=======
+>>>>>>> f90081e... handle case when on all tab
+          const file = await createCSVDataDump(type);
+          return res.download(file);
+        }
       case "xml":
         return res.status(500, "XML not implemented yet").render();
       case "html": // fall through

--- a/api/helpers/create-csv-data-dump.js
+++ b/api/helpers/create-csv-data-dump.js
@@ -61,9 +61,7 @@ async function createCSVDataDump(type) {
     if (editedEntry.creator) {
       editedEntry.creator_id = editedEntry.creator.user_id;
       editedEntry.creator_name = sanitizeUserName(editedEntry.creator.name);
-      editedEntry.creator_profile_url = `https://participedia.net/user/${
-        editedEntry.creator.user_id
-      }`;
+      editedEntry.creator_profile_url = `https://participedia.net/user/${editedEntry.creator.user_id}`;
     }
 
     if (editedEntry.last_updated_by) {
@@ -71,9 +69,7 @@ async function createCSVDataDump(type) {
       editedEntry.last_updated_by_name = sanitizeUserName(
         editedEntry.last_updated_by.name
       );
-      editedEntry.last_updated_by_profile_url = `https://participedia.net/user/${
-        editedEntry.last_updated_by.user_id
-      }`;
+      editedEntry.last_updated_by_profile_url = `https://participedia.net/user/${editedEntry.last_updated_by.user_id}`;
     }
 
     // make sure all date fields are in the same format, ISO 8601

--- a/api/helpers/create-csv-data-dump.js
+++ b/api/helpers/create-csv-data-dump.js
@@ -1,0 +1,355 @@
+const fs = require("fs");
+const { parse } = require("json2csv");
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 862784f... exclude some keys from csv file
+=======
+const moment = require("moment");
+>>>>>>> 7353754... make data format changes and reorder fields
+const {
+  db,
+  LIST_ARTICLES,
+  CASE_BY_ID,
+  METHOD_BY_ID,
+  ORGANIZATION_BY_ID
+} = require("./db.js");
+<<<<<<< HEAD
+
+function sanitizeUserName(name) {
+  let editedName = name;
+  // if the user name is an email address, remove email domain part
+  const atSymbolIndex = name.indexOf("@");
+  if (atSymbolIndex > 0) {
+    editedName = name.substr(0, atSymbolIndex);
+  }
+  return editedName;
+}
+
+async function createCSVDataDump(type) {
+  const entries = await db.many(LIST_ARTICLES, {
+    type: type + "s",
+    lang: "en"
+  });
+=======
+const { db, LIST_ARTICLES, CASE_BY_ID, METHOD_BY_ID, ORGANIZATION_BY_ID } = require("./db.js");
+
+async function createCSVDataDump(type) {
+  const entries = await db.many(LIST_ARTICLES, { type: type+"s", lang: "en" });
+>>>>>>> edadbf0... make it work for all article types
+=======
+
+async function createCSVDataDump(type) {
+  const entries = await db.many(LIST_ARTICLES, {
+    type: type + "s",
+    lang: "en"
+  });
+>>>>>>> 862784f... exclude some keys from csv file
+
+  const sqlForType = {
+    case: CASE_BY_ID,
+    method: METHOD_BY_ID,
+    organization: ORGANIZATION_BY_ID
+  };
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 862784f... exclude some keys from csv file
+  const keysToExclude = [
+    "creator",
+    "bookmarked",
+    "last_updated_by",
+    "published",
+    "featured",
+    "authors",
+    "hidden"
+  ];
+
+<<<<<<< HEAD
+=======
+>>>>>>> edadbf0... make it work for all article types
+=======
+>>>>>>> 862784f... exclude some keys from csv file
+=======
+>>>>>>> 7353754... make data format changes and reorder fields
+  const fullEntries = [];
+  await Promise.all(
+    entries.map(async article => {
+      const params = {
+        type: type,
+        view: "view",
+        articleid: article.id,
+        lang: "en",
+<<<<<<< HEAD
+<<<<<<< HEAD
+        userid: null
+      };
+      const articleRow = await db.one(sqlForType[type], params);
+      keysToExclude.forEach(key => {
+        delete articleRow.results[key];
+      });
+=======
+        userid: null,
+      };
+<<<<<<< HEAD
+      const articleRow = await db.one(sqlForType[type], params);
+>>>>>>> edadbf0... make it work for all article types
+      fullEntries.push(articleRow.results);
+=======
+      const articleRow = await db.one(sqlForType[type], params).results;
+      fullEntries.push(articleRow);
+>>>>>>> 2a4ea82... don't include hidden articles
+    })
+=======
+        userid: null
+      };
+      const articleRow = await db.one(sqlForType[type], params);
+      fullEntries.push(articleRow.results);
+<<<<<<< HEAD
+    });
+>>>>>>> 862784f... exclude some keys from csv file
+=======
+    })
+>>>>>>> f401a2c... delete semi-colon typo
+  );
+
+<<<<<<< HEAD
+  const fields = Object.keys(fullEntries[0]);
+<<<<<<< HEAD
+=======
+const { db, LIST_ARTICLES, CASE_BY_ID } = require("./db.js");
+
+// TODO:
+// - add methods and organizations data as well
+
+async function createCSVDataDump() {
+  const cases = await db.many(LIST_ARTICLES, { type: "cases", lang: "en" });
+
+  const fullCases = [];
+  await Promise.all(cases.map(async (article) => {
+    const params = {
+      type: 'case',
+      view: 'view',
+      articleid: article.id,
+      lang: 'en',
+      userid: null,
+      returns: 'json'
+    };
+    const articleRow = await db.one(CASE_BY_ID, params);
+    fullCases.push(articleRow.results);
+  }));
+
+  const fields = Object.keys(fullCases[0]);
+>>>>>>> 9416005... use list_articles to get all entries
+=======
+>>>>>>> edadbf0... make it work for all article types
+=======
+  const editedEntries = fullEntries.map(entry => {
+    const editedEntry = Object.assign({}, entry);
+    // add article url
+    editedEntry.url = `https://participedia.net/${editedEntry.type}/${
+      editedEntry.id
+    }`;
+
+    // strip html from body
+    editedEntry.body = editedEntry.body.replace(/<\/?[^>]+(>|$)/g, " ");
+
+    // add creator and last_updated_by name and profile url
+    if (editedEntry.creator) {
+      editedEntry.creator_id = editedEntry.creator.user_id;
+      editedEntry.creator_name = sanitizeUserName(editedEntry.creator.name);
+      editedEntry.creator_profile_url = `https://participedia.net/user/${
+        editedEntry.creator.user_id
+      }`;
+    }
+
+    if (editedEntry.last_updated_by) {
+      editedEntry.last_updated_by_id = editedEntry.last_updated_by.user_id;
+      editedEntry.last_updated_by_name = sanitizeUserName(
+        editedEntry.last_updated_by.name
+      );
+      editedEntry.last_updated_by_profile_url = `https://participedia.net/user/${
+        editedEntry.last_updated_by.user_id
+      }`;
+    }
+
+    // make sure all date fields are in the same format, ISO 8601
+    const dateFields = ["post_date", "updated_date", "start_date", "end_date"];
+    dateFields.forEach(field => {
+      editedEntry[field] = moment(editedEntry[field]).toISOString();
+    });
+
+    // add is_component_of_id, is_component_of_title, is_component_of_url
+    // with url of parent component
+    if (editedEntry.type === "case" && editedEntry.is_component_of) {
+      editedEntry.is_component_of_id = editedEntry.is_component_of.id;
+      editedEntry.is_component_of_title = editedEntry.is_component_of.title;
+      editedEntry.is_component_of_url =
+        `https://participedia.net/${editedEntry.is_component_of.type}/${editedEntry.is_component_of.id}`;
+    }
+
+    // primary_organizer
+    if (editedEntry.primary_organizer) {
+      editedEntry.primary_organizer_id = editedEntry.primary_organizer.id;
+      editedEntry.primary_organizer_title = editedEntry.primary_organizer.title;
+      editedEntry.primary_organizer_url = `https://participedia.net/${editedEntry.primary_organizer.type}/${editedEntry.primary_organizer.id}`;
+    }
+
+    // add counts for media, links and other detailed list fields
+    const countFields = [
+      "files",
+      "links",
+      "photos",
+      "videos",
+      "audio",
+      "evaluation_reports",
+      "evaluation_links"
+    ];
+    countFields.forEach(field => {
+      if (editedEntry[field]) {
+        editedEntry[`${field}_count`] = editedEntry[field].length;
+      } else {
+        editedEntry[`${field}_count`] = 0;
+      }
+    });
+
+    // convert specific_methods_tools_techniques, has_components to list of titles
+    const articlesToListOfTitles = [
+      "has_components",
+      "specific_methods_tools_techniques"
+    ];
+    articlesToListOfTitles.forEach(field => {
+      if (editedEntry[field]) {
+        editedEntry[field + "_titles"] = editedEntry[field]
+          .map(item => item.title)
+          .join(", ");
+      }
+    });
+
+    // convert simple arrays to strings
+    const simpleArrayFields = [
+      "general_issues",
+      "specific_topics",
+      "implementers_of_change",
+      "change_types",
+      "funder_types",
+      "organizer_types",
+      "insights_outcomes",
+      "if_voting",
+      "decision_methods",
+      "learning_resources",
+      "participants_interactions",
+      "tools_techniques_types",
+      "method_types",
+      "targeted_participants",
+      "approaches",
+      "purposes"
+    ];
+    simpleArrayFields.forEach(field => {
+      editedEntry[field] = editedEntry[field].toString().replace(/,/g, ", ");
+    });
+
+    // reorder fields
+    const orderOfFields = [
+      "id",
+      "type",
+      "title",
+      "url",
+      "description",
+      "featured",
+      "post_date",
+      "updated_date",
+      "creator_id",
+      "creator_name",
+      "creator_profile_url",
+      "last_updated_by_id",
+      "last_updated_by_name",
+      "last_updated_by_profile_url",
+      "original_language",
+      "address1",
+      "address2",
+      "city",
+      "province",
+      "postal_code",
+      "country",
+      "latitude",
+      "longitude",
+      "is_component_of_id",
+      "is_component_of_title",
+      "is_component_of_url",
+      "specific_methods_tools_techniques_titles",
+      "has_components_titles",
+      "general_issues",
+      "specific_topics",
+      "scope_of_influence",
+      "start_date",
+      "end_date",
+      "ongoing",
+      "time_limited",
+      "purposes",
+      "approaches",
+      "public_spectrum",
+      "number_of_participants",
+      "open_limited",
+      "recruitment_method",
+      "targeted_participants",
+      "method_types",
+      "tools_techniques_types",
+      "legality",
+      "facilitators",
+      "facilitator_training",
+      "facetoface_online_or_both",
+      "participants_interactions",
+      "learning_resources",
+      "decision_methods",
+      "if_voting",
+      "insights_outcomes",
+      "primary_organizer_id",
+      "primary_organizer_title",
+      "primary_organizer_url",
+      "organizer_types",
+      "funder",
+      "funder_types",
+      "staff",
+      "volunteers",
+      "impact_evidence",
+      "change_types",
+      "implementers_of_change",
+      "formal_evaluation",
+      "body",
+      "files_count",
+      "links_count",
+      "photos_count",
+      "videos_count",
+      "audio_count",
+      "evaluation_reports_count",
+      "evaluation_links_count"
+    ];
+
+    const orderedEntry = {};
+    orderOfFields.forEach(field => {
+      orderedEntry[field] = editedEntry[field];
+    });
+
+    return orderedEntry;
+  });
+
+  const fields = Object.keys(editedEntries[0]);
+
+>>>>>>> 7353754... make data format changes and reorder fields
+  const opts = { fields };
+
+  const csv = parse(editedEntries, opts);
+
+  const filePath = `./public/participedia-data-${type}s.csv`;
+
+  fs.writeFileSync(filePath, csv);
+
+  return filePath;
+}
+
+module.exports = createCSVDataDump;

--- a/api/helpers/create-csv-data-dump.js
+++ b/api/helpers/create-csv-data-dump.js
@@ -1,14 +1,6 @@
 const fs = require("fs");
 const { parse } = require("json2csv");
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 862784f... exclude some keys from csv file
-=======
 const moment = require("moment");
->>>>>>> 7353754... make data format changes and reorder fields
 const {
   db,
   LIST_ARTICLES,
@@ -16,7 +8,6 @@ const {
   METHOD_BY_ID,
   ORGANIZATION_BY_ID
 } = require("./db.js");
-<<<<<<< HEAD
 
 function sanitizeUserName(name) {
   let editedName = name;
@@ -33,20 +24,6 @@ async function createCSVDataDump(type) {
     type: type + "s",
     lang: "en"
   });
-=======
-const { db, LIST_ARTICLES, CASE_BY_ID, METHOD_BY_ID, ORGANIZATION_BY_ID } = require("./db.js");
-
-async function createCSVDataDump(type) {
-  const entries = await db.many(LIST_ARTICLES, { type: type+"s", lang: "en" });
->>>>>>> edadbf0... make it work for all article types
-=======
-
-async function createCSVDataDump(type) {
-  const entries = await db.many(LIST_ARTICLES, {
-    type: type + "s",
-    lang: "en"
-  });
->>>>>>> 862784f... exclude some keys from csv file
 
   const sqlForType = {
     case: CASE_BY_ID,
@@ -54,28 +31,6 @@ async function createCSVDataDump(type) {
     organization: ORGANIZATION_BY_ID
   };
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 862784f... exclude some keys from csv file
-  const keysToExclude = [
-    "creator",
-    "bookmarked",
-    "last_updated_by",
-    "published",
-    "featured",
-    "authors",
-    "hidden"
-  ];
-
-<<<<<<< HEAD
-=======
->>>>>>> edadbf0... make it work for all article types
-=======
->>>>>>> 862784f... exclude some keys from csv file
-=======
->>>>>>> 7353754... make data format changes and reorder fields
   const fullEntries = [];
   await Promise.all(
     entries.map(async article => {
@@ -84,70 +39,14 @@ async function createCSVDataDump(type) {
         view: "view",
         articleid: article.id,
         lang: "en",
-<<<<<<< HEAD
-<<<<<<< HEAD
         userid: null
       };
       const articleRow = await db.one(sqlForType[type], params);
-      keysToExclude.forEach(key => {
-        delete articleRow.results[key];
-      });
-=======
-        userid: null,
-      };
-<<<<<<< HEAD
-      const articleRow = await db.one(sqlForType[type], params);
->>>>>>> edadbf0... make it work for all article types
+
       fullEntries.push(articleRow.results);
-=======
-      const articleRow = await db.one(sqlForType[type], params).results;
-      fullEntries.push(articleRow);
->>>>>>> 2a4ea82... don't include hidden articles
     })
-=======
-        userid: null
-      };
-      const articleRow = await db.one(sqlForType[type], params);
-      fullEntries.push(articleRow.results);
-<<<<<<< HEAD
-    });
->>>>>>> 862784f... exclude some keys from csv file
-=======
-    })
->>>>>>> f401a2c... delete semi-colon typo
   );
 
-<<<<<<< HEAD
-  const fields = Object.keys(fullEntries[0]);
-<<<<<<< HEAD
-=======
-const { db, LIST_ARTICLES, CASE_BY_ID } = require("./db.js");
-
-// TODO:
-// - add methods and organizations data as well
-
-async function createCSVDataDump() {
-  const cases = await db.many(LIST_ARTICLES, { type: "cases", lang: "en" });
-
-  const fullCases = [];
-  await Promise.all(cases.map(async (article) => {
-    const params = {
-      type: 'case',
-      view: 'view',
-      articleid: article.id,
-      lang: 'en',
-      userid: null,
-      returns: 'json'
-    };
-    const articleRow = await db.one(CASE_BY_ID, params);
-    fullCases.push(articleRow.results);
-  }));
-
-  const fields = Object.keys(fullCases[0]);
->>>>>>> 9416005... use list_articles to get all entries
-=======
->>>>>>> edadbf0... make it work for all article types
-=======
   const editedEntries = fullEntries.map(entry => {
     const editedEntry = Object.assign({}, entry);
     // add article url
@@ -340,7 +239,6 @@ async function createCSVDataDump() {
 
   const fields = Object.keys(editedEntries[0]);
 
->>>>>>> 7353754... make data format changes and reorder fields
   const opts = { fields };
 
   const csv = parse(editedEntries, opts);

--- a/api/helpers/create-csv-data-dump.js
+++ b/api/helpers/create-csv-data-dump.js
@@ -57,6 +57,14 @@ async function createCSVDataDump(type) {
     // strip html from body
     editedEntry.body = editedEntry.body.replace(/<\/?[^>]+(>|$)/g, " ");
 
+    // max characters for an excel cell is 32766 so trimming
+    // the body length so excel doesn't throw errors
+    // https://support.office.com/en-us/article/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
+    const MAX_CHAR_LENGTH = 32766;
+    if (editedEntry.body && editedEntry.body.length > MAX_CHAR_LENGTH) {
+      editedEntry.body = editedEntry.body.substring(0, MAX_CHAR_LENGTH);
+    }
+
     // add creator and last_updated_by name and profile url
     if (editedEntry.creator) {
       editedEntry.creator_id = editedEntry.creator.user_id;

--- a/api/sql/list_articles.sql
+++ b/api/sql/list_articles.sql
@@ -4,4 +4,5 @@ WITH all_titles AS
  ORDER BY title)
 SELECT *
 FROM all_titles
-WHERE title IS NOT NULL;
+WHERE title IS NOT NULL
+AND hidden IS NOT TRUE;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2177,8 +2177,7 @@
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "common-tags": {
       "version": "1.8.0",
@@ -6161,6 +6160,16 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json2csv": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-4.5.1.tgz",
+      "integrity": "sha512-o90Xa1ziGk3i7AJEO79Jac4+7SEUk58/DxS5mDPW6GF7poX0y7Y0pm1FbWrkz9VzKE4MpUW9aKBOCpJ0U1Ua8A==",
+      "requires": {
+        "commander": "^2.15.1",
+        "jsonparse": "^1.3.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "json5": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
@@ -6204,8 +6213,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonwebtoken": {
       "version": "7.4.1",
@@ -6586,8 +6594,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "i18n": "0.8.3",
     "js-md5": "0.7.3",
     "json-pretty": "^0.0.1",
+    "json2csv": "4.5.1",
     "jsonwebtoken": "^7.3.0",
     "jwks-rsa": "^1.1.1",
     "keypair": "^1.0.1",


### PR DESCRIPTION
makes the following urls download a csv with data for each type:
`/?selectedCategory=case&returns=csv`
`/?selectedCategory=method&returns=csv`
`/?selectedCategory=organizations&returns=csv`

@dethe i ended up reusing the `${THING}_BY_ID` sql to get all the needed localized values, but not sure if there is a more efficient way to do this.