### PR TITLE
fix missing images on homepage and user profile page for article cards

### DIFF
--- a/views/partials/article-card.html
+++ b/views/partials/article-card.html
@@ -9,7 +9,7 @@
   <a href="/{{type}}/{{id}}" class="js-article-link">
     <div
       class="article-card-img js-article-card-img"
-      style="background-image: url('{{getFirstImageForArticle this}}')"
+      style='background-image: url("{{getFirstImageForArticle this}}")'
     ></div>
 
     <div class="article-card-content">


### PR DESCRIPTION
change single quotes to double quotes so url strings with unescaped characters will still load

reference: https://stackoverflow.com/questions/2168855/is-quoting-the-value-of-url-really-necessary

fixes: https://github.com/participedia/api/issues/621, https://github.com/participedia/usersnaps/issues/764, https://github.com/participedia/usersnaps/issues/699, 
https://github.com/participedia/usersnaps/issues/652