### PR TITLE
add js cache key to js build files

### DIFF
--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const moment = require("moment");
 const md5 = require("js-md5");
 const aboutData = require("./data/about-data.js");
@@ -652,6 +653,12 @@ module.exports = {
     } else {
       return name;
     }
+  },
+
+  jsCacheVersion(filepath) {
+    // return last modified datetime in ms for filepath
+    const stats = fs.statSync(`${process.env.PWD}/public${filepath}`);
+    return stats.mtimeMs;
   },
 
   // data

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -37,36 +37,36 @@
 
   {{> contact-help-faq }}
 
-  <script type="text/javascript" src="/build/js/app.bundle.js"></script>
+  {{> script-tag-with-cache-key filepath="/build/js/app.bundle.js"}}
 
   {{#if (isHomeSearchView req)}}
     {{!-- import google api for the map widget --}}
     <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAYi8w5HOVTr3HyioFkAKUK_PofGow_7uA&libraries=places&language={{static.language}}"></script>
-    <script type="text/javascript" src="/build/js/home-search-view.bundle.js"></script>
+    {{> script-tag-with-cache-key filepath="/build/js/home-search-view.bundle.js"}}
   {{/if}}
 
   {{#if (isEditView req)}}
     {{!-- import google api for the autocomplete widget --}}
     <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAYi8w5HOVTr3HyioFkAKUK_PofGow_7uA&libraries=places&language={{static.language}}"></script>
     <script type="text/javascript" src="/js/polyfills/DragDropTouch.js"></script>
-    <script type="text/javascript" src="/build/js/edit-view.bundle.js"></script>
+    {{> script-tag-with-cache-key filepath="/build/js/edit-view.bundle.js"}}
   {{/if}}
 
   {{#if (isNewView req)}}
     {{!-- import google api for the autocomplete widget --}}
     <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAYi8w5HOVTr3HyioFkAKUK_PofGow_7uA&libraries=places&language={{static.language}}"></script>
     <script type="text/javascript" src="/js/polyfills/DragDropTouch.js"></script>
-    <script type="text/javascript" src="/build/js/edit-view.bundle.js"></script>
+    {{> script-tag-with-cache-key filepath="/build/js/edit-view.bundle.js"}}
   {{/if}}
 
   {{#if (isReaderView req)}}
     <script type="text/javascript" src="/js/vendor/flickity@2.2.0-flickity.pkgd.js"></script>
     <script type="text/javascript" src="/js/vendor/flickity-fullscreen@1.1.1-fullscreen.js"></script>
-    <script type="text/javascript" src="/build/js/reader-view.bundle.js"></script>
+    {{> script-tag-with-cache-key filepath="/build/js/reader-view.bundle.js"}}
   {{/if}}
 
   {{#if (isUserView req)}}
-    <script type="text/javascript" src="/build/js/user-view.bundle.js"></script>
+    {{> script-tag-with-cache-key filepath="/build/js/user-view.bundle.js"}}
   {{/if}}
 
   {{!-- initialize usersnap   --}}

--- a/views/partials/script-tag-with-cache-key.html
+++ b/views/partials/script-tag-with-cache-key.html
@@ -1,4 +1,4 @@
 <script
   type="text/javascript"
-  src="{{filepath}}?{{jsCacheVersion filepath}}">
+  src="{{filepath}}?cacheKey={{jsCacheVersion filepath}}">
 </script>

--- a/views/partials/script-tag-with-cache-key.html
+++ b/views/partials/script-tag-with-cache-key.html
@@ -1,0 +1,4 @@
+<script
+  type="text/javascript"
+  src="{{filepath}}?{{jsCacheVersion filepath}}">
+</script>


### PR DESCRIPTION
this will force the browser to load the latest js file when changes have been made, so the user doesn't have to do a hard refresh to get the latest changes.

fixes: https://github.com/participedia/api/issues/644