### PR TITLE
666 localization

### DIFF
--- a/api/sql/case_by_id.sql
+++ b/api/sql/case_by_id.sql
@@ -72,7 +72,7 @@ SELECT
   hidden
 FROM
   cases,
-  get_localized_texts(${articleid}, ${lang}) as localized_texts
+  get_localized_texts_fallback(${articleid}, ${lang}, cases.original_language) as localized_texts
 WHERE
   cases.id = ${articleid}
 

--- a/api/sql/featured.sql
+++ b/api/sql/featured.sql
@@ -29,7 +29,7 @@ WITH all_featured  AS (
     bookmarked(type, id, ${userId})
   FROM
     ${type:name},
-    get_localized_texts(${type:name}.id, ${language}) AS texts
+    get_localized_texts_fallback(${type:name}.id, ${language}, ${type:name}.original_language) AS texts
   WHERE
    ${type:name}.hidden = false
    ${facets:raw}

--- a/api/sql/featuredmap.sql
+++ b/api/sql/featuredmap.sql
@@ -27,7 +27,7 @@ SELECT
   post_date
 FROM
   ${type:name},
-  get_localized_texts(${type:name}.id, ${language}) AS texts
+  get_localized_texts_fallback(${type:name}.id, ${language}, ${type:name}.original_language) AS texts
 WHERE
   ${type:name}.hidden = false
   ${facets:raw}

--- a/api/sql/method_by_id.sql
+++ b/api/sql/method_by_id.sql
@@ -40,7 +40,7 @@ WITH full_thing AS (
     purpose_method
 FROM
     methods,
-    get_localized_texts(${articleid}, ${lang}) AS texts
+    get_localized_texts_fallback(${articleid}, ${lang}, methods.original_language) AS texts
 WHERE
     methods.id = ${articleid}
 )

--- a/api/sql/organization_by_id.sql
+++ b/api/sql/organization_by_id.sql
@@ -44,7 +44,7 @@ WITH full_thing AS (
     get_object_title_list(specific_methods_tools_techniques, ${lang}) as specific_methods_tools_techniques
 FROM
     organizations,
-    get_localized_texts(${articleid}, ${lang}) AS texts
+    get_localized_texts_fallback(${articleid}, ${lang}, organizations.original_language) AS texts
 WHERE
     organizations.id = ${articleid}
 )

--- a/api/sql/search.sql
+++ b/api/sql/search.sql
@@ -48,7 +48,7 @@ FROM
   all_selections,
   total_selections,
   ${type:name},
-  get_localized_texts(${type:name}.id, ${language}) AS texts
+  get_localized_texts_fallback(${type:name}.id, ${language}, ${type:name}.original_language) AS texts
 WHERE
   all_selections.id = ${type:name}.id AND
   ${type:name}.hidden = false

--- a/api/sql/searchmap.sql
+++ b/api/sql/searchmap.sql
@@ -34,7 +34,7 @@ SELECT
   post_date
 FROM
   ${type:name},
-  get_localized_texts(${type:name}.id, ${language}) AS texts
+  get_localized_texts_fallback(${type:name}.id, ${language}, ${type:name}.original_language) AS texts
 Where
   ${type:name}.hidden = false
       ${facets:raw}

--- a/api/sql/thing_by_id.sql
+++ b/api/sql/thing_by_id.sql
@@ -14,7 +14,7 @@ WITH full_thing AS (
     bookmarked(${table:name}.type, ${thingid}, ${userId})
 FROM
     ${table:name},
-    get_localized_texts(${thingid}, ${lang}) AS texts
+    get_localized_texts_fallback(${thingid}, ${lang}, ${table:name}.original_language) AS texts
 WHERE
     ${table:name}.id = ${thingid}
 )

--- a/api/sql/user_by_id.sql
+++ b/api/sql/user_by_id.sql
@@ -11,7 +11,7 @@ WITH user_bookmarks AS (
     FROM
       bookmarks,
       things,
-      get_localized_texts(things.id, ${language}) AS texts
+      get_localized_texts_fallback(things.id, ${language}, things.original_language) AS texts
     WHERE
       things.hidden = false AND
       bookmarks.userid = ${userId} AND
@@ -28,7 +28,7 @@ authored_things AS (
   FROM
     authors,
     things,
-    get_localized_texts(things.id, ${language}) AS texts
+    get_localized_texts_fallback(things.id, ${language}, things.original_language) AS texts
   WHERE
     texts.thingid = authors.thingid AND
     texts.thingid = things.id AND

--- a/migrations/all_migrations.sql
+++ b/migrations/all_migrations.sql
@@ -56,3 +56,5 @@
 \include 'migrations/migration_038.sql'
 -- add columns level_complexity and purpose_method
 \include 'migrations/migration_039.sql'
+-- Add fallback for languages that don't have local localization
+\include `migrations/migration_040.sql`

--- a/migrations/migration_040.sql
+++ b/migrations/migration_040.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION get_localized_texts_fallback(id integer, lang text, origlang text) RETURNS localized_texts
+  LANGUAGE sql STABLE
+  AS $_$
+  select * from  get_localized_texts(
+    id,
+    coalesce(
+      (
+        select language from localized_texts where language = lang and thingid = id limit 1
+      ),
+      origlang
+    )
+  );
+$_$;

--- a/migrations/update_migrations.sql
+++ b/migrations/update_migrations.sql
@@ -44,3 +44,5 @@
 \include 'migrations/migration_038.sql'
 -- add columns level_complexity and purpose_method
 \include 'migrations/migration_039.sql'
+-- Add fallback for languages that don't have local localization
+\include `migrations/migration_040.sql`


### PR DESCRIPTION
Add fallback for localized text: if no text is available in the current language, return text in original language. 

Fixes participedia/usersnaps#773
Partial fix for #666 

Requires `npm run migratelocal 40`. I've already run migration on stage and prod.

Known issues: Does not add fallback text to full text search, so finding by full text still won't turn up these articles, unless it happens to match metadata that we do index.
