### PR TITLE
article reader view: give data column a max width

### DIFF
--- a/public/css/reader-view.css
+++ b/public/css/reader-view.css
@@ -80,6 +80,10 @@ article .reader-view-social-links {
   display: none;
 }
 
+.reader-view .data-column-inner {
+  max-width: 270px;
+}
+
 @media (max-width: 850px) {
   .reader-view .language-select {
     display: block;

--- a/views/partials/view-container.html
+++ b/views/partials/view-container.html
@@ -1,11 +1,13 @@
 <div class="full-width-container reader-view">
   <div class="left-col data-column">
-    {{> language-select }}
+    <div class="data-column-inner">
+      {{> language-select }}
 
-    <!-- Data and Metadata -->
-    <h2>{{t "Data"}}</h2>
+      <!-- Data and Metadata -->
+      <h2>{{t "Data"}}</h2>
 
-    {{> @partial-block }}
+      {{> @partial-block }}
+    </div>
   </div>
   <div class="middle-col">
     <article>


### PR DESCRIPTION
article reader view: give data column a max width, so on really wide screens it will only ever be 270px wide.
fixes: https://github.com/participedia/usersnaps/issues/806
@jesicarson 
<img width="686" alt="Screenshot 2019-07-26 00 04 15" src="https://user-images.githubusercontent.com/130878/61932729-f847df80-af38-11e9-89ee-32c302f4654d.png">
<img width="896" alt="Screenshot 2019-07-26 00 02 18" src="https://user-images.githubusercontent.com/130878/61932730-f847df80-af38-11e9-848b-a0ea881f62dc.png">
