### PR TITLE
Error Logging: send errors from catch blocks to new relic

### DIFF
--- a/api/controllers/bookmark.js
+++ b/api/controllers/bookmark.js
@@ -44,7 +44,7 @@ async function lookupBookmarksById(req, res, userId) {
       message: "Retrieved ALL bookmarks for specified user"
     });
   } catch (error) {
-    newrelic.noticeError(error, { req: req, errorMessage: "Exception in lookupBookmarksById" });
+    newrelic.noticeError(error, { req, errorMessage: "Exception in lookupBookmarksById" });
     res.json({ success: false, error: error.message || error });
   }
 }
@@ -58,7 +58,7 @@ async function queryBookmarks(req, res) {
     }
     lookupBookmarksById(req, res, userid);
   } catch (error) {
-    newrelic.noticeError(error, { req: req, errorMessage: "Exception in queryBookmarks" });
+    newrelic.noticeError(error, { req, errorMessage: "Exception in queryBookmarks" });
     res.json({ success: false, error: error.message || error });
   }
 }
@@ -95,7 +95,7 @@ router.post("/add", async function addBookmark(req, res) {
   try {
     if (!req.body.bookmarkType) {
       newrelic.noticeError(error, {
-        req: req,
+        req,
         errorMessage: "Required parameter (bookmarkType) wasn't specified"
       });
       res.status(400).json({
@@ -105,7 +105,7 @@ router.post("/add", async function addBookmark(req, res) {
     }
     if (!req.body.thingid) {
       newrelic.noticeError(error, {
-        req: req,
+        req,
         errorMessage: "Required parameter (thingid) wasn't specified"
       });
       res
@@ -143,7 +143,7 @@ router.post("/add", async function addBookmark(req, res) {
       message: "Inserted bookmark, returning ID"
     });
   } catch (error) {
-    newrelic.noticeError(error, { req: req, errorMessage: "Exception in /user/add" });
+    newrelic.noticeError(error, { req, errorMessage: "Exception in /user/add" });
     res.status(500).json({
       success: false,
       error: error.message || error
@@ -194,7 +194,7 @@ router.delete("/delete", async function updateUser(req, res) {
     );
     res.status(200).json({ status: "success", message: `Removed a bookmark` });
   } catch (error) {
-    newrelic.noticeError(error, { req: req, errorMessage: "Exception in /user/delete" });
+    newrelic.noticeError(error, { req, errorMessage: "Exception in /user/delete" });
     res.json({
       success: false,
       error: error.message || error

--- a/api/controllers/bookmark.js
+++ b/api/controllers/bookmark.js
@@ -4,7 +4,7 @@ let router = express.Router(); // eslint-disable-line new-cap
 let groups = require("../helpers/groups");
 let { db, as } = require("../helpers/db");
 let { userByEmail } = require("../helpers/user");
-let log = require("winston");
+const newrelic = require("newrelic");
 
 /**
  * @api {get} /bookmark/list/:userId List bookmarks for a given user
@@ -44,7 +44,7 @@ async function lookupBookmarksById(req, res, userId) {
       message: "Retrieved ALL bookmarks for specified user"
     });
   } catch (error) {
-    log.error(error);
+    newrelic.noticeError(error, { req: req, errorMessage: "Exception in lookupBookmarksById" });
     res.json({ success: false, error: error.message || error });
   }
 }
@@ -58,7 +58,7 @@ async function queryBookmarks(req, res) {
     }
     lookupBookmarksById(req, res, userid);
   } catch (error) {
-    log.error(error);
+    newrelic.noticeError(error, { req: req, errorMessage: "Exception in queryBookmarks" });
     res.json({ success: false, error: error.message || error });
   }
 }
@@ -94,21 +94,26 @@ router.get("/list/:userid", queryBookmarks);
 router.post("/add", async function addBookmark(req, res) {
   try {
     if (!req.body.bookmarkType) {
-      log.error("Required parameter (bookmarkType) wasn't specified");
+      newrelic.noticeError(error, {
+        req: req,
+        errorMessage: "Required parameter (bookmarkType) wasn't specified"
+      });
       res.status(400).json({
         message: "Required parameter (bookmarkType) wasn't specified"
       });
       return;
     }
     if (!req.body.thingid) {
-      log.error("Required parameter (thingid) wasn't specified");
+      newrelic.noticeError(error, {
+        req: req,
+        errorMessage: "Required parameter (thingid) wasn't specified"
+      });
       res
         .status(400)
         .json({ error: "Required parameter (thingid) wasn't specified" });
       return;
     }
     if (!req.user) {
-      log.error("No user");
       res.status(401).json({ error: "You must be logged in to perform this action." });
       return;
     }
@@ -138,7 +143,7 @@ router.post("/add", async function addBookmark(req, res) {
       message: "Inserted bookmark, returning ID"
     });
   } catch (error) {
-    log.error("Exception in INSERT", error);
+    newrelic.noticeError(error, { req: req, errorMessage: "Exception in /user/add" });
     res.status(500).json({
       success: false,
       error: error.message || error
@@ -189,7 +194,7 @@ router.delete("/delete", async function updateUser(req, res) {
     );
     res.status(200).json({ status: "success", message: `Removed a bookmark` });
   } catch (error) {
-    log.error("Error deleting bookmark", error);
+    newrelic.noticeError(error, { req: req, errorMessage: "Exception in /user/delete" });
     res.json({
       success: false,
       error: error.message || error

--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -296,7 +296,7 @@ async function getCase(params, res) {
     fixUpURLs(article);
     return article;
   } catch (error) {
-    newrelic.noticeError(error, { errorMessage: "Exception in getCase" });
+    newrelic.noticeError(error, { errorMessage: "No entry found", params: params });
     // if no entry is found, render the 404 page
     return res.status(404).render("404");
   }

--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -1,7 +1,7 @@
 "use strict";
 const express = require("express");
 const cache = require("apicache");
-const log = require("winston");
+const newrelic = require("newrelic");
 const equals = require("deep-equal");
 const fs = require("fs");
 
@@ -86,7 +86,7 @@ async function postCaseNewHttp(req, res) {
     req.params.thingid = thing.thingid;
     await postCaseUpdateHttp(req, res);
   } catch (error) {
-    log.error("Exception in POST /case/new => %s", error);
+    newrelic.noticeError(error, { req, errorMessage: "Exception in postCaseNewHttp" });
     res.status(400).json({ OK: false, error: error });
   }
 }
@@ -254,6 +254,7 @@ async function postCaseUpdateHttp(req, res) {
     });
     refreshSearch();
   } else {
+
     console.error("Reporting errors: %s", er.errors);
     res.status(400).json({
       OK: false,
@@ -295,8 +296,9 @@ async function getCase(params, res) {
     fixUpURLs(article);
     return article;
   } catch (error) {
+    newrelic.noticeError(error, { errorMessage: "Exception in getCase" });
     // if no entry is found, render the 404 page
-    return res.sendStatus("404");
+    return res.status(404).render("404");
   }
 }
 

--- a/api/controllers/list.js
+++ b/api/controllers/list.js
@@ -1,7 +1,6 @@
 "use strict";
 const express = require("express");
 const router = express.Router(); // eslint-disable-line new-cap
-const log = require("winston");
 
 const { db, as, LIST_TITLES, LIST_SHORT } = require("../helpers/db");
 const { supportedTypes } = require("../helpers/things");

--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -95,7 +95,7 @@ async function postMethodNewHttp(req, res) {
     req.params.thingid = thing.thingid;
     await postMethodUpdateHttp(req, res);
   } catch (error) {
-    newrelic.noticeError(error, { req: req, errorMessage: "Exception in postMethodNewHttp" });
+    newrelic.noticeError(error, { req, errorMessage: "Exception in postMethodNewHttp" });
     res.status(400).json({ OK: false, error: error });
   }
 }
@@ -133,6 +133,7 @@ async function getMethod(params, res) {
     fixUpURLs(article);
     return article;
   } catch (error) {
+    newrelic.noticeError(error, { errorMessage: "No entry found", params: params });
     // if no entry is found, render the 404 page
     return res.status(404).render("404");
   }
@@ -200,7 +201,7 @@ async function postMethodUpdateHttp(req, res) {
     refreshSearch();
   } else {
     newrelic.noticeError(er, {
-      req: req,
+      req,
       errorMessage: er.errors
     });
     res.status(400).json({

--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -2,7 +2,7 @@
 
 const express = require("express");
 const cache = require("apicache");
-const log = require("winston");
+const newrelic = require("newrelic");
 const fs = require("fs");
 
 const {
@@ -95,7 +95,7 @@ async function postMethodNewHttp(req, res) {
     req.params.thingid = thing.thingid;
     await postMethodUpdateHttp(req, res);
   } catch (error) {
-    log.error("Exception in POST /method/new => %s", error);
+    newrelic.noticeError(error, { req: req, errorMessage: "Exception in postMethodNewHttp" });
     res.status(400).json({ OK: false, error: error });
   }
 }
@@ -134,7 +134,7 @@ async function getMethod(params, res) {
     return article;
   } catch (error) {
     // if no entry is found, render the 404 page
-    return res.sendStatus("404");
+    return res.status(404).render("404");
   }
 }
 
@@ -199,7 +199,10 @@ async function postMethodUpdateHttp(req, res) {
     });
     refreshSearch();
   } else {
-    console.error("Reporting errors: %s", er.errors);
+    newrelic.noticeError(er, {
+      req: req,
+      errorMessage: er.errors
+    });
     res.status(400).json({
       OK: false,
       errors: er.errors

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -94,7 +94,7 @@ async function postOrganizationNewHttp(req, res) {
     req.params.thingid = thing.thingid;
     await postOrganizationUpdateHttp(req, res);
   } catch (error) {
-    newrelic.noticeError(error, { req: req, errorMessage: "Exception in postOrganizationNewHttp" });
+    newrelic.noticeError(error, { req, errorMessage: "Exception in postOrganizationNewHttp" });
     return res.status(400).json({ OK: false, error: error });
   }
 }
@@ -133,7 +133,7 @@ async function getOrganization(params, res) {
     return article;
   } catch (error) {
     // if no entry is found, render the 404 page
-    newrelic.noticeError(error, { errorMessage: "No entry found" });
+    newrelic.noticeError(error, { errorMessage: "No entry found", params: params });
     return res.status(404).render("404");
   }
 }
@@ -186,7 +186,6 @@ async function postOrganizationUpdateHttp(req, res) {
     refreshSearch();
   } else {
     console.error("Reporting errors: %s", er.errors);
-    newrelic.noticeError(er, { req: req, errorMessage: er.errors });
     res.status(400).json({
       OK: false,
       errors: er.errors

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -2,7 +2,7 @@
 
 const express = require("express");
 const cache = require("apicache");
-const log = require("winston");
+const newrelic = require("newrelic");
 const fs = require("fs");
 
 const {
@@ -94,7 +94,7 @@ async function postOrganizationNewHttp(req, res) {
     req.params.thingid = thing.thingid;
     await postOrganizationUpdateHttp(req, res);
   } catch (error) {
-    log.error("Exception in POST /organization/new => %s", error);
+    newrelic.noticeError(error, { req: req, errorMessage: "Exception in postOrganizationNewHttp" });
     return res.status(400).json({ OK: false, error: error });
   }
 }
@@ -133,7 +133,8 @@ async function getOrganization(params, res) {
     return article;
   } catch (error) {
     // if no entry is found, render the 404 page
-    return res.sendStatus("404");
+    newrelic.noticeError(error, { errorMessage: "No entry found" });
+    return res.status(404).render("404");
   }
 }
 
@@ -185,6 +186,7 @@ async function postOrganizationUpdateHttp(req, res) {
     refreshSearch();
   } else {
     console.error("Reporting errors: %s", er.errors);
+    newrelic.noticeError(er, { req: req, errorMessage: er.errors });
     res.status(400).json({
       OK: false,
       errors: er.errors

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -76,7 +76,7 @@ router.get("/getAllForType", async function getAllForType(req, res) {
     res.status(200).json(jtitlelist);
   } catch (error) {
     newrelic.noticeError(error, {
-      req: req,
+      req,
       errorMessage: "Exception in GET /search/getAllForType"
     });
     res.status(500).json({ error: error });
@@ -285,7 +285,7 @@ router.get("/", async function(req, res) {
   } catch (error) {
     console.error("Error in search: ", error);
     console.trace(error);
-    newrelic.noticeError(error, { req: req });
+    newrelic.noticeError(error, { req, });
     let OK = false;
     res.status(500).json({ OK, error });
   }
@@ -313,7 +313,7 @@ router.get("/map", async function(req, res) {
     res.status(200).json({ data: { cases, orgs } });
   } catch (error) {
     newrelic.noticeError(error, {
-      req: req,
+      req,
       errorMessage: "Exception in GET /search/map"
     });
     res.status(500).json({ error: error });

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -13,7 +13,7 @@ let {
   LIST_MAP_ORGANIZATIONS
 } = require("../helpers/db");
 let { preparse_query } = require("../helpers/search");
-let log = require("winston");
+const newrelic = require("newrelic");
 const { supportedTypes, parseGetParams } = require("../helpers/things");
 const createCSVDataDump = require("../helpers/create-csv-data-dump.js");
 
@@ -75,7 +75,10 @@ router.get("/getAllForType", async function getAllForType(req, res) {
     });
     res.status(200).json(jtitlelist);
   } catch (error) {
-    log.error("Exception in GET /search/getAllForType", error);
+    newrelic.noticeError(error, {
+      req: req,
+      errorMessage: "Exception in GET /search/getAllForType"
+    });
     res.status(500).json({ error: error });
   }
 });
@@ -282,6 +285,7 @@ router.get("/", async function(req, res) {
   } catch (error) {
     console.error("Error in search: ", error);
     console.trace(error);
+    newrelic.noticeError(error, { req: req });
     let OK = false;
     res.status(500).json({ OK, error });
   }
@@ -308,7 +312,10 @@ router.get("/map", async function(req, res) {
 
     res.status(200).json({ data: { cases, orgs } });
   } catch (error) {
-    log.error("Exception in GET /search/map", error);
+    newrelic.noticeError(error, {
+      req: req,
+      errorMessage: "Exception in GET /search/map"
+    });
     res.status(500).json({ error: error });
   }
 });

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -64,7 +64,7 @@ async function getUserById(userId, req, res, view = "view") {
       };
     }
   } catch (error) {
-    newrelic.noticeError(error, { req: req, errorMessage: `Exception in getUserById` });
+    newrelic.noticeError(error, { req, errorMessage: "Exception in getUserById" });
     if (error.message && error.message == "No data returned from the query.") {
       res.status(404).json({ OK: false });
     } else {
@@ -108,6 +108,7 @@ router.get("/:userId", async function(req, res) {
   } catch (error) {
     console.error("Problem in /user/:userId");
     console.trace(error);
+    newrelic.noticeError(error, { req, errorMessage: "Exception in /user/:userId" });
   }
 });
 
@@ -127,6 +128,7 @@ router.get("/:userId/edit", requireAuthenticatedUser(), async function(
   } catch (error) {
     console.error("Problem in /user/:userId/edit");
     console.trace(error);
+    newrelic.noticeError(error, { req, errorMessage: "Problem in /user/:userId/edit" });
   }
 });
 
@@ -141,6 +143,7 @@ router.get("/", async function(req, res) {
   } catch (error) {
     console.error("Problem in /user/");
     console.trace(error);
+    newrelic.noticeError(error, { req, errorMessage: "Problem in /user/" });
   }
 });
 
@@ -190,7 +193,7 @@ router.post("/", async function(req, res) {
     });
     res.status(200).json({ OK: true, user: { id: user.id } });
   } catch (error) {
-    newrelic.noticeError(error, { req: req, errorMessage: `Exception in POST /user` });
+    newrelic.noticeError(error, { req, errorMessage: `Exception in POST /user` });
     if (error.message && error.message == "No data returned from the query.") {
       res.status(404).json({ OK: false });
     } else {

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -2,7 +2,7 @@
 let express = require("express");
 let router = express.Router(); // eslint-disable-line new-cap
 let cache = require("apicache");
-let log = require("winston");
+const newrelic = require("newrelic");
 let { db, as, USER_BY_ID, UPDATE_USER } = require("../helpers/db");
 let { fixUpURLs } = require("../helpers/things");
 
@@ -64,8 +64,7 @@ async function getUserById(userId, req, res, view = "view") {
       };
     }
   } catch (error) {
-    log.error("Exception in GET /user/%s => %s", userId, error);
-    console.trace(error);
+    newrelic.noticeError(error, { req: req, errorMessage: `Exception in getUserById` });
     if (error.message && error.message == "No data returned from the query.") {
       res.status(404).json({ OK: false });
     } else {
@@ -191,7 +190,7 @@ router.post("/", async function(req, res) {
     });
     res.status(200).json({ OK: true, user: { id: user.id } });
   } catch (error) {
-    log.error("Exception in POST /user => %s", error);
+    newrelic.noticeError(error, { req: req, errorMessage: `Exception in POST /user` });
     if (error.message && error.message == "No data returned from the query.") {
       res.status(404).json({ OK: false });
     } else {

--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -13,7 +13,6 @@ const fs = require("fs");
 //}
 const pgp = require("pg-promise")(options);
 const path = require("path");
-const log = require("winston");
 const connectionString = process.env.DATABASE_URL;
 const parse = require("pg-connection-string").parse;
 let config;

--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -1,5 +1,4 @@
 let { isString } = require("lodash");
-let log = require("winston");
 const cache = require("apicache");
 const equals = require("deep-equal");
 const moment = require("moment");

--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ const morgan = require("morgan");
 const bodyParser = require("body-parser");
 const methodOverride = require("method-override");
 const cors = require("cors");
+const newrelic = require("newrelic");
 
 // Actual Participedia APIS vs. Nodejs gunk
 const handlebarsHelpers = require("./api/helpers/handlebars-helpers.js");
@@ -280,6 +281,7 @@ app.get("/robots.txt", function(req, res, next) {
 // 404 error handling
 // this should always be after all routes to catch all invalid urls
 app.use((req, res, next) => {
+  newrelic.noticeError("Throw 404 from app.js catch-all", { req: req });
   res.status(404).render("404");
 });
 

--- a/app.js
+++ b/app.js
@@ -281,7 +281,7 @@ app.get("/robots.txt", function(req, res, next) {
 // 404 error handling
 // this should always be after all routes to catch all invalid urls
 app.use((req, res, next) => {
-  newrelic.noticeError("Throw 404 from app.js catch-all", { req: req });
+  newrelic.noticeError("404 from app.js catch-all", { req });
   res.status(404).render("404");
 });
 

--- a/newrelic.js
+++ b/newrelic.js
@@ -15,6 +15,10 @@ exports.config = {
    * Your New Relic license key.
    */
   license_key: process.env.NEW_RELIC_LICENSE_KEY,
+  error_collector: {
+    enabled: true,
+    ignore_status_codes: [],
+  },
   logging: {
     /**
      * Level at which to log. 'trace' is most useful to New Relic when diagnosing

--- a/package-lock.json
+++ b/package-lock.json
@@ -2185,11 +2185,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-    },
     "combine-source-map": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
@@ -2529,11 +2524,6 @@
       "requires": {
         "lodash.get": "~4.4.2"
       }
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "cypress": {
       "version": "3.2.0",
@@ -4164,11 +4154,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -12746,11 +12731,6 @@
         }
       }
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -13806,26 +13786,6 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "optional": true
-    },
-    "winston": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
-      "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
-        }
-      }
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "sinon": "^7.3.1",
     "sortablejs": "1.9.0",
     "tape": "^4.6.3",
-    "uuid": "3.3.2",
-    "winston": "^2.3.1"
+    "uuid": "3.3.2"
   },
   "devDependencies": {
     "auth0": "^2.14.0",

--- a/test/setupenv.js
+++ b/test/setupenv.js
@@ -3,7 +3,6 @@ let jwt = require("jsonwebtoken");
 let pem2jwk = require("pem-jwk").pem2jwk;
 let keypair = require("keypair");
 let nock = require("nock");
-let log = require("winston");
 
 // We expect to not have an AUTH0_SECRET
 let process = require("process");
@@ -57,7 +56,6 @@ try {
   jwt.verify(bearer_token, pair.public, { algorithms: ["RS256"] });
 } catch (e) {
   // useful for early detection that something went wrong with signing.
-  log.error(JSON.stringify(e));
   throw e;
 }
 


### PR DESCRIPTION
- removes winston dependency (we weren't using it)
- adds new relic logging to catch blocks to send the errors to new relic