### PR TITLE
phrase app config file change for github sync

### DIFF
--- a/.phraseapp.yml
+++ b/.phraseapp.yml
@@ -3,13 +3,13 @@ phraseapp:
   project_id: process.env.PHRASE_APP_PROJECT_ID
   push:
     sources:
-    - file: ./locales/<locale_name>.js
+    - file: ./locales/en.js
       params:
         file_format: node_json
         update_translations: true
   pull:
     targets:
-    - file: ./locales/<locale_name>.js
+    - file: ./locales/en.js
       params:
         file_format: node_json
         update_translations: true


### PR DESCRIPTION
the `<locale_name>` placeholder was left in the config file, updated to use the default locale of `en`.