### PR TITLE
edit forms: improve request timeout/server unavailable error handling for users

### DIFF
--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -201,13 +201,6 @@ function getUpdatedCase(user, params, newCase, oldCase) {
 // Only changes to title, description, and/or body trigger a new author and version
 
 async function postCaseUpdateHttp(req, res) {
-  res.setTimeout(10000, () => {
-    // make the request timeout after 10 seconds and send 408 error to client
-    // this is to avoid the situation of the user having to wait a really long time
-    // (longer than 10s) with no feedback if the server is taking a long time to respond
-    return res.send(408);
-  });
-
   cache.clear();
   const params = parseGetParams(req, "case");
   const user = req.user;

--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -201,7 +201,7 @@ function getUpdatedCase(user, params, newCase, oldCase) {
 // Only changes to title, description, and/or body trigger a new author and version
 
 async function postCaseUpdateHttp(req, res) {
-  cache.clear();
+  // cache.clear();
   const params = parseGetParams(req, "case");
   const user = req.user;
   const { articleid, type, view, userid, lang, returns } = params;

--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -201,7 +201,14 @@ function getUpdatedCase(user, params, newCase, oldCase) {
 // Only changes to title, description, and/or body trigger a new author and version
 
 async function postCaseUpdateHttp(req, res) {
-  // cache.clear();
+  res.setTimeout(10000, () => {
+    // make the request timeout after 10 seconds and send 408 error to client
+    // this is to avoid the situation of the user having to wait a really long time
+    // (longer than 10s) with no feedback if the server is taking a long time to respond
+    return res.send(408);
+  });
+
+  cache.clear();
   const params = parseGetParams(req, "case");
   const user = req.user;
   const { articleid, type, view, userid, lang, returns } = params;

--- a/public/js/edit-form.js
+++ b/public/js/edit-form.js
@@ -27,7 +27,7 @@ const editForm = {
         this.openInfoModal(event);
       });
     }
-    
+
     // if this page was loaded with the refreshAndClose param, we can close it programmatically
     // this is part of the flow to refresh auth state
     if (window.location.search.indexOf("refreshAndClose") > 0) {
@@ -74,10 +74,6 @@ const editForm = {
     xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
 
     xhr.onreadystatechange = () => {
-      if (xhr.readyState === 2) {
-        this.openPublishingFeedbackModal();
-      }
-
       // wait for request to be done
       if (xhr.readyState !== xhr.DONE) return;
 
@@ -89,6 +85,11 @@ const editForm = {
         this.handleErrors([
           "Sorry your files are too large. Try uploading one at at time or uploading smaller files (50mb total)."
         ]);
+      } else if (xhr.status === 408 || xhr.status === 503) {
+        // handle server unavailable/request timeout errors
+        // show default, sorry something went wrong, please try again msg
+        // so the user can try again and doesn't lose their input
+        this.handleErrors(null);
       } else {
         const response = JSON.parse(xhr.response);
 
@@ -101,6 +102,8 @@ const editForm = {
     }
 
     xhr.send(formData);
+    // open publishing feedback modal as soon as we send the request
+    this.openPublishingFeedbackModal();
   },
 
   openAuthWarning() {

--- a/public/js/edit-form.js
+++ b/public/js/edit-form.js
@@ -9,6 +9,11 @@ const editForm = {
 
     if (!submitButtonEls) return;
 
+    // this is a counter to keep track of publishing attempts
+    // if the server returns with a 408 or a 503 (timeout errors)
+    // we want to automatically retry a max of MAX_PUBLISH_ATTEMPTS
+    // this is a stopgap to improve ux until we fix the underlying server issues.
+    this.MAX_PUBLISH_ATTEMPTS = 10;
     this.publishAttempts = 0;
 
     for (let i = 0; i < submitButtonEls.length; i++) {
@@ -91,7 +96,7 @@ const editForm = {
       } else if (xhr.status === 408 || xhr.status === 503) {
         // handle server unavailable/request timeout errors
         // rather than showing
-        if (this.publishAttempts < 10) {
+        if (this.publishAttempts < this.MAX_PUBLISH_ATTEMPTS) {
           this.sendFormData();
           this.publishAttempts++;
         } else {


### PR DESCRIPTION
creates a better user experience in cases where the server takes a long time to respond. currently if the server responds with a 503 error, the client doesn't handle it gracefully which results in the page just hanging on the publishing modal. 

related issues: 
https://github.com/participedia/usersnaps/issues/826
https://github.com/participedia/usersnaps/issues/805

this change adds a max request timeout of 10 seconds when adding or editing an article. if the response takes longer than 10s we send a 408 error back to the client and show the user the "Sorry something went wrong message." This allows the user to close the error so they can try submitting the form again.  If the server had crashed, they might be logged out, and so they will get the sorry you are logged out error, which will take them through the refresh login flow, and back to their article so they can submit again (without losing their inputted data). Here is a gif of that simulated flow:

![participedia-server-time-out](https://user-images.githubusercontent.com/130878/63219267-e1a13c80-c122-11e9-9c08-d8f66b272c8e.gif)

we also want to solve the server issue of the server time-ing out, but this will at least improve the user experience when it does happen.


