### PR TITLE
case view: make any filterable field in the data side bar link to the search results

### DIFF
--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -205,6 +205,23 @@ module.exports = {
   },
 
   // article helpers
+  isLinkableTerm: (article, name) => {
+    const supportedArticleTypes = ["case"];
+
+    if (!supportedArticleTypes.includes(article.type)) return;
+
+    // get all the keys that we are currently filtering on from the search filters list
+    const supportedFilters = [].concat.apply([], searchFiltersList[article.type].map(section => {
+      return section.fieldNameKeys.map(key => key);
+    }));
+
+    return supportedFilters.includes(name);
+  },
+
+  getSearchLinkForTerm: (article, name, key) => {
+    return `/?selectedCategory=${article.type}&${name}=${key}`;
+  },
+
   getFirstImageForArticle: article => {
     if (article.photos && article.photos.length > 0) {
       // search pages return photos for articles in this format
@@ -255,15 +272,21 @@ module.exports = {
     }
   },
 
-  getArrayOfValues: (article, name, context) => {
+  getLocalizedValuesForKeys: (article, name, context) => {
     const arrayOfItems = article[name];
     if (!arrayOfItems || arrayOfItems.length === 0) return;
 
     return arrayOfItems.map(item => {
       if (typeof item === "string") {
-        return i18n(`name:${name}-key:${item}`, context);
+        return {
+          key: item,
+          localizedValue: i18n(`name:${name}-key:${item}`, context)
+        }
       } else {
-        return i18n(`name:${name}-key:${item.key}`, context);
+        return {
+          key: item.key,
+          localizedValue: i18n(`name:${name}-key:${item.key}`, context)
+        }
       }
     });
   },

--- a/views/partials/view-list.html
+++ b/views/partials/view-list.html
@@ -2,11 +2,31 @@
 <dl>
   <dt>{{label article name}}</dt>
   {{#if (isArray article name)}}
-    {{#each (getArrayOfValues article name) }}
-      <dd>{{this}}</dd>
+    {{#each (getLocalizedValuesForKeys article name) }}
+      {{#if (isLinkableTerm ../article ../name)}}
+        <dd>
+          <a
+            href="{{getSearchLinkForTerm ../article ../name key}}"
+          >
+            {{localizedValue}}
+          </a>
+        </dd>
+      {{else}}
+        <dd>{{localizedValue}}</dd>
+      {{/if}}
     {{/each}}
   {{else}}
-    <dd>{{getArticleSelectValue article name}}</dd>
+    {{#if (isLinkableTerm article name)}}
+      <dd>
+        <a
+          href="{{getSearchLinkForTerm article name (lookup article name)}}"
+        >
+          {{getArticleSelectValue article name}}
+        </a>
+      </dd>
+    {{else}}
+      <dd>{{getArticleSelectValue article name}}</dd>
+    {{/if}}
   {{/if}}
 </dl>
 {{/if}}


### PR DESCRIPTION
any search filter available for cases (except location for now) is linked to a search results page for that filter from the data side bar:

![Screenshot 2019-08-21 11 42 28](https://user-images.githubusercontent.com/130878/63459127-e0189280-c408-11e9-9a30-029d99cfbb64.png)

the link takes you to the search results page with results filtered for that field/key.
![Screenshot 2019-08-21 11 45 57](https://user-images.githubusercontent.com/130878/63459272-10603100-c409-11e9-9117-bbd0a7e89334.png)

@jesicarson @dethe 