### PR TITLE
Teaching page: remove FB group chat link section

### DIFF
--- a/views/teaching-view.html
+++ b/views/teaching-view.html
@@ -26,6 +26,10 @@
     </ol>
   </section>
 
+{{!--
+  // The FB chat has been deactivated, so we are taking this out until
+  // we figure out where we are hosting the group chat
+
   <section>
     <h2>{{t "teaching.Discussions & Questions About Our Resources"}}</h2>
     <p>{{t "teaching.Discussion.p1"}}</p>
@@ -39,6 +43,7 @@
       {{t "teaching.Join Group Chat About Teaching Resources"}}
     </a>
   </section>
+--}}
 
   <section>
     <h2>{{t "teaching.Share Your Resources with the Community"}}</h2>


### PR DESCRIPTION
fixes: https://github.com/participedia/usersnaps/issues/829
> FB chat in groups will no longer function after aug 22. We need to adjust or delete this copy to point to a new system, or delete this section. 