### PR TITLE
switche trace() to error()

### DIFF
--- a/api/controllers/list.js
+++ b/api/controllers/list.js
@@ -38,7 +38,7 @@ router.get("/titles", async (req, res) => {
     });
     res.status(200).json({ OK: true, data: retVal });
   } catch (error) {
-    console.trace("Exception in POST /list/titles => %s", error);
+    console.error("Exception in POST /list/titles => %s", error.message);
     return res.status(500).json({ OK: false, error: error });
   }
 });
@@ -53,7 +53,7 @@ router.get("/short", async (req, res) => {
     });
     res.status(200).json({ OK: true, data: retVal });
   } catch (error) {
-    console.trace("Exception in POST /list/short => %s", error);
+    console.error("Exception in POST /list/short => %s", error.message);
     return res.status(500).json({ OK: false, error: error });
   }
 });
@@ -69,7 +69,11 @@ router.get("/:type", async (req, res) => {
     const query = await db.one(LIST_REFERENCES, { language });
     res.status(200).json({ OK: true, data: query.results });
   } catch (error) {
-    console.trace("Exception in POST /list/%s => %s", req.params.type, error);
+    console.error(
+      "Exception in POST /list/%s => %s",
+      req.params.type,
+      error.message
+    );
     return res.status(500).json({ OK: false, error: error });
   }
 });

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -262,7 +262,8 @@ router.get("/", async function(req, res) {
       case "csv":
         if (type === "thing") {
           return res.status(200).json({
-            msg: "You can only get a csv file from cases, methods or organizations tabs."
+            msg:
+              "You can only get a csv file from cases, methods or organizations tabs."
           });
         } else {
           const file = await createCSVDataDump(type);
@@ -283,8 +284,7 @@ router.get("/", async function(req, res) {
         });
     }
   } catch (error) {
-    console.error("Error in search: ", error);
-    console.trace(error);
+    console.error("Error in /search: %s", error.message);
     logError(error);
     let OK = false;
     res.status(500).json({ OK, error });

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -107,8 +107,11 @@ router.get("/:userId", async function(req, res) {
       res.status(200).json(data);
     }
   } catch (error) {
-    console.error("Problem in /user/:userId");
-    console.trace(error);
+    console.error(
+      "Exception in /user/%s => %s",
+      req.params.userId,
+      error.message
+    );
     logError(error);
   }
 });
@@ -127,8 +130,11 @@ router.get("/:userId/edit", requireAuthenticatedUser(), async function(
     // return html template
     res.status(200).render(`user-edit`, data);
   } catch (error) {
-    console.error("Problem in /user/:userId/edit");
-    console.trace(error);
+    console.error(
+      "Exception in in /user/%s/edit => %s",
+      req.params.userId,
+      error.message
+    );
     logError(error);
   }
 });
@@ -142,8 +148,7 @@ router.get("/", async function(req, res) {
     }
     return getUserById(req.user.user_id, req, res);
   } catch (error) {
-    console.error("Problem in /user/");
-    console.trace(error);
+    console.error("Exception in /user/ => %s", error.message);
     logError(error);
   }
 });
@@ -199,7 +204,7 @@ router.post("/", async function(req, res) {
       res.status(404).json({ OK: false });
     } else {
       res.status(500).json({ OK: false, error: error });
-      console.trace(error);
+      console.error("Exception in POST /user => %s", error.message);
     }
   }
 });

--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -79,7 +79,7 @@ function ErrorReporter() {
         return fn(...args);
       } catch (e) {
         self.errors.push(e.message);
-        console.trace("Capturing error to report to client: " + e.message);
+        console.error("Capturing error to report to client: " + e.message);
         return e.message;
       }
     };


### PR DESCRIPTION
Using trace() is great in the browser console, but not sure what I was thinking putting them in server-side logging, they output so much information (of such useless quality) that the real data is drowned out. Heck, they may even be contributing to our memory and responsiveness woes. In any case, they are doing more harm than good.