### PR TITLE
Edit forms: replace native HTML select with customizable select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12569,6 +12569,11 @@
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
+    "slim-select": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/slim-select/-/slim-select-1.23.0.tgz",
+      "integrity": "sha512-9HiHPNQZUMZ9zS5YJxQOEWp5PsyQPSHlI+tqwXLunqQct/uIkXRCpqc8tZQRilwdL0pZCF/9+guSYifUOVbazg=="
+    },
     "smart-buffer": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "quill": "^1.3.6",
     "react-dropzone-s3-uploader": "^1.0.0-rc.3",
     "sinon": "^7.3.1",
+    "slim-select": "1.23.0",
     "sortablejs": "1.9.0",
     "tape": "^4.6.3",
     "uuid": "3.3.2"

--- a/public/css/edit-form.css
+++ b/public/css/edit-form.css
@@ -260,6 +260,23 @@ input[type=number]::-webkit-inner-spin-button {
   margin-bottom: 0px;
 }
 
+.ss-main .placeholder,
+.ss-main .placeholder .ss-disabled {
+  color: #000!important;
+  line-height: 1.3em;
+}
+
+.edit-multi-select .ss-option-selected {
+  cursor: pointer!important;
+  color: #000!important;
+  background-color: #fff!important;
+}
+
+.edit-multi-select .ss-option-selected:hover {
+  background-color: #5897fb!important;
+  color: #fff!important;
+}
+
 .edit-multi-select-list,
 .edit-media-file-list {
   margin-top: 15px;

--- a/public/css/edit-form.css
+++ b/public/css/edit-form.css
@@ -260,12 +260,6 @@ input[type=number]::-webkit-inner-spin-button {
   margin-bottom: 0px;
 }
 
-.ss-main .placeholder,
-.ss-main .placeholder .ss-disabled {
-  color: #000!important;
-  line-height: 1.3em;
-}
-
 .edit-multi-select .ss-option-selected {
   cursor: pointer!important;
   color: #000!important;

--- a/public/css/reader-view.css
+++ b/public/css/reader-view.css
@@ -109,8 +109,8 @@ article .reader-view-social-links {
     width: 50%;
   }
 
-  .floating-action-button-reader-view {
-    right: 30px;
+  .floating-action-button {
+    right: 32px;
   }
 
   .reader-view.full-width-container .right-col {

--- a/public/css/slim-select.css
+++ b/public/css/slim-select.css
@@ -1,0 +1,286 @@
+.ss-main {
+  position: relative;
+  display: inline-block;
+  user-select: none;
+  color: #000;
+  width: 100%; }
+  .ss-main .ss-single-selected {
+    display: flex;
+    cursor: pointer;
+    width: 100%;
+    height: 40px;
+    padding: 10px;
+    border: 1px solid #000;
+    border-radius: 2px;
+    background-color: #ffffff;
+    outline: 0;
+    box-sizing: border-box;
+    transition: background-color .2s; }
+    .ss-main .ss-single-selected.ss-disabled {
+      background-color: #dcdee2;
+      cursor: not-allowed; }
+    .ss-main .ss-single-selected.ss-open-above {
+      border-top-left-radius: 0px;
+      border-top-right-radius: 0px; }
+    .ss-main .ss-single-selected.ss-open-below {
+      border-bottom-left-radius: 0px;
+      border-bottom-right-radius: 0px; }
+    .ss-main .ss-single-selected .placeholder {
+      display: inline;
+
+      // this feels hacky, but it makes the placeholder text take up the full width of the container
+      width: 0;
+
+      flex: 1 1 100%;
+      align-items: center;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      text-align: left;
+      line-height: 1em;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none; }
+      .ss-main .ss-single-selected .placeholder * {
+        display: flex;
+        align-items: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: auto; }
+      .ss-main .ss-single-selected .placeholder .ss-disabled {
+        color: #dedede; }
+    .ss-main .ss-single-selected .ss-deselect {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      flex: 0 1 auto;
+      margin: 0 6px 0 6px;
+      font-weight: bold; }
+      .ss-main .ss-single-selected .ss-deselect.ss-hide {
+        display: none; }
+    .ss-main .ss-single-selected .ss-arrow {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      flex: 0 1 auto;
+      margin: 0 6px 0 6px; }
+      .ss-main .ss-single-selected .ss-arrow span {
+        border: solid #666666;
+        border-width: 0 2px 2px 0;
+        display: inline-block;
+        padding: 3px;
+        transition: transform .2s, margin .2s; }
+        .ss-main .ss-single-selected .ss-arrow span.arrow-up {
+          transform: rotate(-135deg);
+          margin: 3px 0 0 0; }
+        .ss-main .ss-single-selected .ss-arrow span.arrow-down {
+          transform: rotate(45deg);
+          margin: -3px 0 0 0; }
+  .ss-main .ss-multi-selected {
+    display: flex;
+    flex-direction: row;
+    cursor: pointer;
+    min-height: 30px;
+    width: 100%;
+    padding: 0 0 0 3px;
+    border: 1px solid #dcdee2;
+    border-radius: 2px;
+    background-color: #ffffff;
+    outline: 0;
+    box-sizing: border-box;
+    transition: background-color .2s; }
+    .ss-main .ss-multi-selected.ss-disabled {
+      background-color: #dcdee2;
+      cursor: not-allowed; }
+      .ss-main .ss-multi-selected.ss-disabled .ss-values .ss-disabled {
+        color: #666666; }
+      .ss-main .ss-multi-selected.ss-disabled .ss-values .ss-value .ss-value-delete {
+        cursor: not-allowed; }
+    .ss-main .ss-multi-selected.ss-open-above {
+      border-top-left-radius: 0px;
+      border-top-right-radius: 0px; }
+    .ss-main .ss-multi-selected.ss-open-below {
+      border-bottom-left-radius: 0px;
+      border-bottom-right-radius: 0px; }
+    .ss-main .ss-multi-selected .ss-values {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+      flex: 1 1 100%;
+      width: calc(100% - 30px); }
+      .ss-main .ss-multi-selected .ss-values .ss-disabled {
+        display: flex;
+        padding: 4px 5px;
+        margin: 2px 0px;
+        line-height: 1em;
+        align-items: center;
+        width: 100%;
+        color: #dedede;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap; }
+
+@keyframes scaleIn {
+  0% {
+    transform: scale(0);
+    opacity: 0; }
+  100% {
+    transform: scale(1);
+    opacity: 1; } }
+
+@keyframes scaleOut {
+  0% {
+    transform: scale(1);
+    opacity: 1; }
+  100% {
+    transform: scale(0);
+    opacity: 0; } }
+      .ss-main .ss-multi-selected .ss-values .ss-value {
+        display: flex;
+        user-select: none;
+        align-items: center;
+        font-size: 12px;
+        padding: 3px 5px;
+        margin: 3px 5px 3px 0px;
+        color: #ffffff;
+        background-color: #5897fb;
+        border-radius: 2px;
+        animation-name: scaleIn;
+        animation-duration: .2s;
+        animation-timing-function: ease-out;
+        animation-fill-mode: both; }
+        .ss-main .ss-multi-selected .ss-values .ss-value.ss-out {
+          animation-name: scaleOut;
+          animation-duration: .2s;
+          animation-timing-function: ease-out; }
+        .ss-main .ss-multi-selected .ss-values .ss-value .ss-value-delete {
+          margin: 0 0 0 5px;
+          cursor: pointer; }
+    .ss-main .ss-multi-selected .ss-add {
+      display: flex;
+      flex: 0 1 3px;
+      margin: 9px 12px 0 5px; }
+      .ss-main .ss-multi-selected .ss-add .ss-plus {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: #666666;
+        position: relative;
+        height: 10px;
+        width: 2px;
+        transition: transform .2s; }
+        .ss-main .ss-multi-selected .ss-add .ss-plus:after {
+          background: #666666;
+          content: "";
+          position: absolute;
+          height: 2px;
+          width: 10px;
+          left: -4px;
+          top: 4px; }
+        .ss-main .ss-multi-selected .ss-add .ss-plus.ss-cross {
+          transform: rotate(45deg); }
+  .ss-main .ss-content {
+    position: absolute;
+    width: 100%;
+    margin: -1px 0 0 0;
+    box-sizing: border-box;
+    border: solid 1px #dcdee2;
+    z-index: 1010;
+    background-color: #ffffff;
+    transform-origin: center top;
+    transition: transform .2s, opacity .2s;
+    opacity: 0;
+    transform: scaleY(0); }
+    .ss-main .ss-content.ss-open {
+      display: block;
+      opacity: 1;
+      transform: scaleY(1); }
+    .ss-main .ss-content .ss-search {
+      display: flex;
+      flex-direction: row;
+      padding: 8px 8px 6px 8px; }
+      .ss-main .ss-content .ss-search.ss-hide {
+        height: 0px;
+        opacity: 0;
+        padding: 0px 0px 0px 0px;
+        margin: 0px 0px 0px 0px; }
+        .ss-main .ss-content .ss-search.ss-hide input {
+          height: 0px;
+          opacity: 0;
+          padding: 0px 0px 0px 0px;
+          margin: 0px 0px 0px 0px; }
+      .ss-main .ss-content .ss-search input {
+        display: inline-flex;
+        font-size: inherit;
+        line-height: inherit;
+        flex: 1 1 auto;
+        width: 100%;
+        min-width: 0px;
+        height: 30px;
+        padding: 6px 8px;
+        margin: 0;
+        border: 1px solid #dcdee2;
+        border-radius: 2px;
+        background-color: #ffffff;
+        outline: 0;
+        text-align: left;
+        box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        -webkit-appearance: textfield; }
+        .ss-main .ss-content .ss-search input::placeholder {
+          color: #8a8a8a;
+          vertical-align: middle; }
+        .ss-main .ss-content .ss-search input:focus {
+          box-shadow: 0 0 5px #5897fb; }
+      .ss-main .ss-content .ss-search .ss-addable {
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        font-size: 22px;
+        font-weight: bold;
+        flex: 0 0 30px;
+        height: 30px;
+        margin: 0 0 0 8px;
+        border: 1px solid #dcdee2;
+        border-radius: 2px;
+        box-sizing: border-box; }
+    .ss-main .ss-content .ss-addable {
+      padding-top: 0px; }
+    .ss-main .ss-content .ss-list {
+      max-height: 200px;
+      overflow-x: hidden;
+      overflow-y: auto;
+      text-align: left; }
+      .ss-main .ss-content .ss-list .ss-optgroup .ss-optgroup-label {
+        padding: 6px 10px 6px 10px;
+        font-weight: bold; }
+      .ss-main .ss-content .ss-list .ss-optgroup .ss-option {
+        padding: 6px 6px 6px 25px; }
+      .ss-main .ss-content .ss-list .ss-optgroup-label-selectable {
+        cursor: pointer; }
+        .ss-main .ss-content .ss-list .ss-optgroup-label-selectable:hover {
+          color: #ffffff;
+          background-color: #5897fb; }
+      .ss-main .ss-content .ss-list .ss-option {
+        padding: 6px 10px 6px 10px;
+        cursor: pointer;
+        user-select: none; }
+        .ss-main .ss-content .ss-list .ss-option * {
+          display: inline-block; }
+        .ss-main .ss-content .ss-list .ss-option:hover, .ss-main .ss-content .ss-list .ss-option.ss-highlighted {
+          color: #ffffff;
+          background-color: #5897fb; }
+        .ss-main .ss-content .ss-list .ss-option.ss-disabled {
+          cursor: not-allowed;
+          color: #dedede;
+          background-color: #ffffff; }
+        .ss-main .ss-content .ss-list .ss-option:not(.ss-disabled).ss-option-selected {
+          color: #666666;
+          background-color: rgba(88, 151, 251, 0.1); }
+        .ss-main .ss-content .ss-list .ss-option.ss-hide {
+          display: none; }
+        .ss-main .ss-content .ss-list .ss-option .ss-search-highlight {
+          background-color: #fffb8c; }

--- a/public/css/slim-select.css
+++ b/public/css/slim-select.css
@@ -9,7 +9,7 @@
     cursor: pointer;
     width: 100%;
     height: 40px;
-    padding: 10px;
+    padding: 8px;
     border: 1px solid #000;
     border-radius: 2px;
     background-color: #ffffff;
@@ -28,7 +28,7 @@
     .ss-main .ss-single-selected .placeholder {
       display: inline;
 
-      // this feels hacky, but it makes the placeholder text take up the full width of the container
+      /* this feels hacky, but it makes the placeholder text take up the full width of the container */
       width: 0;
 
       flex: 1 1 100%;
@@ -37,11 +37,12 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       text-align: left;
-      line-height: 1em;
+      line-height: 1.4em;
       -webkit-user-select: none;
       -moz-user-select: none;
       -ms-user-select: none;
-      user-select: none; }
+      user-select: none;
+      color: #000; }
       .ss-main .ss-single-selected .placeholder * {
         display: flex;
         align-items: center;
@@ -50,7 +51,7 @@
         white-space: nowrap;
         width: auto; }
       .ss-main .ss-single-selected .placeholder .ss-disabled {
-        color: #dedede; }
+        color: #000; }
     .ss-main .ss-single-selected .ss-deselect {
       display: flex;
       align-items: center;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -14,6 +14,8 @@
 
 @import url("/css/autocomplete.css");
 
+@import url("/css/slim-select.css");
+
 @import url("/css/reader-view.css");
 
 @import url("/css/view-slideshow.css");

--- a/public/js/edit-multi-select.js
+++ b/public/js/edit-multi-select.js
@@ -1,3 +1,4 @@
+import SlimSelect from "slim-select";
 import Sortable from "sortablejs";
 import modal from "./modal.js";
 
@@ -9,9 +10,34 @@ const editMultiSelect = {
 
     if (this.selectLists.length < 1) return;
 
+    this.initSelects();
     this.bindRemoveItemClicks();
-    this.bindOnSelectChange();
     this.initSortableLists();
+  },
+
+  initSelects() {
+    const selectEls = toArray(document.querySelectorAll(".js-edit-multi-select"));
+    selectEls.forEach(selectEl => {
+      const placeholderText = selectEl.querySelector("option[data-placeholder]").innerText;
+      const slim = new SlimSelect({
+        select: `#${selectEl.id}`,
+        placeholder: placeholderText,
+        allowDeselectOption: true,
+      });
+
+      slim.onChange = (info) => {
+        this.onSelectChange({
+          name: selectEl.getAttribute("name"),
+          selectedKey: info.value,
+          selectedText: info.text,
+        });
+      }
+
+      slim.afterClose = (info) => {
+        // always show the placeholder text
+        slim.slim.container.querySelector(".placeholder").innerHTML = placeholderText;
+      }
+    });
   },
 
   initSortableLists() {
@@ -49,28 +75,23 @@ const editMultiSelect = {
     });
   },
 
-  bindOnSelectChange() {
-    const selectEls = toArray(document.querySelectorAll(".js-edit-multi-select"));
-    selectEls.forEach((el) => {
-      el.addEventListener("change", (e) => {
-        this.onSelectChange(e);
-      });
-    });
+  getNumItems(currentList) {
+    const items = toArray(currentList.querySelectorAll("li"));
+    // filter out items where input value is empty
+    return items.filter(item => item.querySelector("input").value !== "").length;
   },
 
-  onSelectChange(e) {
-    const name = e.target.name;
-    const selectedItem = e.target.selectedOptions[0];
+  onSelectChange({ name, selectedKey, selectedText }) {
     const currentList = document.querySelector(`.js-edit-multi-select-list[data-name=${name}]`);
     const currentSelect = document.querySelector(`.js-edit-multi-select[name=${name}]`);
     const maxItems = currentList.getAttribute("data-max");
-    const numItems = currentList.querySelectorAll("li").length;
-    const newItemHTML = this.listItemTemplate(name, selectedItem, numItems);
+    const numItems = this.getNumItems(currentList);
+    const newItemHTML = this.listItemTemplate(name, selectedKey, selectedText, numItems);
 
     const isInList = () => {
       // converts a NodeList into an Array so we can use the find method
       const arrayOfInputs = toArray(currentList.querySelectorAll("input"));
-      return arrayOfInputs.find(el => el.value === selectedItem.value);
+      return arrayOfInputs.find(el => el.value === selectedKey);
     };
 
     const hasNotReachedMax = () => {
@@ -80,7 +101,7 @@ const editMultiSelect = {
 
     if (
       hasNotReachedMax() && // if there is a max number, only allow adding items up to that limit
-      selectedItem.value &&  // if it's the placeholder/top most item, don't append to ui
+      selectedKey &&  // if it's the placeholder/top most item, don't append to ui
       !isInList() // if it's already in the list, don't append to ui
     ) {
       currentList.append(newItemHTML);
@@ -95,9 +116,9 @@ const editMultiSelect = {
     currentSelect.selectedIndex = 0;
   },
 
-  listItemTemplate(name, selectedItem, index) {
-    const key = selectedItem.value;
-    const value = selectedItem.innerText.trim();
+  listItemTemplate(name, selectedkey, selectedText, index) {
+    const key = selectedkey;
+    const value = selectedText.trim();
     const template = document.querySelector("#js-edit-multi-select-list-item");
     const newList = document.createElement("ol");
     newList.innerHTML = template.innerHTML;
@@ -111,10 +132,24 @@ const editMultiSelect = {
   },
 
   removeItem(e) {
+    e.preventDefault();
     const listItem = e.target.closest("li");
     const listContainer = listItem.closest("ol");
-    listContainer.removeChild(listItem);
-    this.updateIndexes(e);
+    const name = listContainer.getAttribute("data-name");
+    const currentList = document.querySelector(`.js-edit-multi-select-list[data-name=${name}]`);
+    const numItems = this.getNumItems(currentList);
+
+    // if it's the last item, don't remove it, set the value to null/"" and hide it
+    // so currently saved values will be deleted.
+    if (numItems === 1) {
+      listItem.querySelector("input").value = "";
+      listItem.style.visibility = "hidden";
+      listItem.style.height = "0";
+      listItem.style.marginBottom = "0";
+    } else {
+      listContainer.removeChild(listItem);
+      this.updateIndexes(e);
+    }
   },
 }
 

--- a/public/js/edit-select.js
+++ b/public/js/edit-select.js
@@ -1,0 +1,17 @@
+import SlimSelect from "slim-select";
+
+const toArray = nodelist => Array.prototype.slice.call(nodelist);
+
+const editSelect = {
+  init() {
+    const selectEls = toArray(document.querySelectorAll(".js-edit-select"));
+    selectEls.forEach(selectEl => {
+      new SlimSelect({
+        select: `#${selectEl.id}`,
+        allowDeselectOption: true,
+      });
+    });
+  },
+}
+
+export default editSelect;

--- a/public/js/edit-view.js
+++ b/public/js/edit-view.js
@@ -8,6 +8,7 @@ import editSubmissionDetails from "./edit-submission-details.js";
 import editTextarea from './edit-textarea.js';
 import editForm from './edit-form.js';
 import editAutocomplete from './edit-autocomplete.js';
+import editSelect from './edit-select.js';
 
 document.addEventListener("DOMContentLoaded", () => {
   editMultiSelect.init();
@@ -20,4 +21,5 @@ document.addEventListener("DOMContentLoaded", () => {
   editTextarea.init();
   editForm.init();
   editAutocomplete.init();
+  editSelect.init();
 });

--- a/views/partials/edit-multi-select.html
+++ b/views/partials/edit-multi-select.html
@@ -2,9 +2,10 @@
   <select
     name="{{name}}"
     class="edit-multi-select js-edit-multi-select"
+    id="js-edit-multi-select-{{name}}"
     {{#if ranked}}data-ranked="true"{{/if}}
   >
-    <option value="">{{placeholder article name}}</option>
+    <option data-placeholder="true" value="">{{placeholder article name}}</option>
     {{#each (getArticleOptions static name)}}
       <option
         value="{{this}}"

--- a/views/partials/edit-select.html
+++ b/views/partials/edit-select.html
@@ -1,6 +1,6 @@
 {{#> edit-form-group quick-submit=quick-submit name=name is_required=is_required}}
-  <select name={{name}}>
-    <option value="">{{placeholder_txt}}</option>
+  <select name={{name}} class="js-edit-select" id="js-edit-select-{{name}}">
+    <option data-placeholder="true" value="">{{placeholder_txt}}</option>
     {{#each options}}
       <option
         value="{{this}}"

--- a/views/partials/view-container.html
+++ b/views/partials/view-container.html
@@ -37,7 +37,7 @@
     {{> view-socialmedia }}
     <a
       href="/{{article.type}}/{{article.id}}/edit"
-      class="button button-red floating-action-button floating-action-button-reader-view"
+      class="button button-red floating-action-button"
       title="{{t 'Edit'}} {{t article.type}}"
     >
       <span class="sr-only">{{t "Edit"}} {{t article.type}}</span>


### PR DESCRIPTION
This select accommodates multi-line options by wrapping on to multiple lines when selecting and using an ellipsis for the placeholder to show what is selected for the single selects. For both multi and single selects, it includes a search filter to filter results in the drop down.

- replaces single and multi/ranked select components
- uses Slim Select https://github.com/brianvoe/slim-select
- fixes multi-select bug where you couldn't delete all items https://github.com/participedia/usersnaps/issues/841
- fixes positioning of floating action button https://github.com/participedia/usersnaps/issues/846

<img width="693" alt="Screenshot 2019-09-03 09 43 53" src="https://user-images.githubusercontent.com/130878/64192260-1dc8e280-ce2f-11e9-9b68-884f1b04bf02.png">
<img width="692" alt="Screenshot 2019-09-03 09 44 11" src="https://user-images.githubusercontent.com/130878/64192261-1efa0f80-ce2f-11e9-9df7-425524907db9.png">

single select:
![participedia-new-single-select](https://user-images.githubusercontent.com/130878/64192309-42bd5580-ce2f-11e9-8bc1-9c226c9288fb.gif)

multi-select:
![participedia-new-multi-select](https://user-images.githubusercontent.com/130878/64192310-4355ec00-ce2f-11e9-9bcb-53846aa9fc7d.gif)


@jesicarson let me know if you'd like to change the highlight/hover/selected color from blue to something else, or if this works for you.

