### PR TITLE
Return 404 for all NaN ids

### DIFF
--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -291,6 +291,9 @@ async function postCaseUpdateHttp(req, res) {
 
 async function getCase(params, res) {
   try {
+    if (Number.isNaN(params.articleid)) {
+      return res.status(404).render("404");
+    }
     const articleRow = await db.one(CASE_BY_ID, params);
     const article = articleRow.results;
     fixUpURLs(article);

--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -129,6 +129,9 @@ async function postMethodNewHttp(req, res) {
 
 async function getMethod(params, res) {
   try {
+    if (Number.isNaN(params.articleid)) {
+      return res.status(404).render("404");
+    }
     const articleRow = await db.one(METHOD_BY_ID, params);
     const article = articleRow.results;
     fixUpURLs(article);

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -128,6 +128,9 @@ async function postOrganizationNewHttp(req, res) {
 
 async function getOrganization(params, res) {
   try {
+    if (Number.isNaN(params.articleid)) {
+      return res.status(404).render("404");
+    }
     const articleRow = await db.one(ORGANIZATION_BY_ID, params);
     const article = articleRow.results;
     fixUpURLs(article);

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -12,7 +12,9 @@ const requireAuthenticatedUser = require("../middleware/requireAuthenticatedUser
 async function getUserById(userId, req, res, view = "view") {
   try {
     const language = req.params.language || "en";
-
+    if (Number.isNaN(userId)) {
+      return res.status(404).render("404");
+    }
     const result = await db.oneOrNone(USER_BY_ID, {
       userId: userId,
       language: language


### PR DESCRIPTION
Fixes #739 

Check for `Number.isNaN(id)` and return a 404, bypassing database query altogether.