### PR TITLE
fixes sentry error: invalid input syntax for integer: "'NaN'"

### DIFF
--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -98,7 +98,7 @@ const parseGetParams = function(req, type) {
   return Object.assign({}, req.query, {
     type,
     view: as.value(req.params.view || "view"),
-    articleid: as.number(req.params.thingid || req.params.articleid),
+    articleid: parseInt(as.number(req.params.thingid || req.params.articleid), 10),
     lang: as.value(getLanguage(req)),
     userid: req.user ? as.number(req.user.id) : null,
     returns: as.value(req.query.returns || "html")


### PR DESCRIPTION
for some reason `as.number` returns "NaN" (as a string) for urls with text instead of numbers, (eg: http://localhost:3001/case/www.sharecast.org.np)


fixes: https://github.com/participedia/api/issues/745