### PR TITLE
use sentry to capture errors rather than console.error

### DIFF
--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -212,21 +212,13 @@ async function postCaseUpdateHttp(req, res) {
     newCase.post_date = Date.now();
   }
 
-  // console.log(
-  //   "Received tools_techniques_types from client: >>> \n%s\n",
-  //   JSON.stringify(newCase.tools_techniques_types, null, 2)
-  // );
   // save any changes to the user-submitted text
   const {
     updatedText,
     author,
     oldArticle: oldCase
   } = await maybeUpdateUserText(req, res, "case");
-  // console.log("oldCase: %s", JSON.stringify(oldCase, null, 2));
-  // console.log("updatedText: %s", JSON.stringify(updatedText));
-  // console.log("author: %s", JSON.stringify(author));
   const [updatedCase, er] = getUpdatedCase(user, params, newCase, oldCase);
-  //console.log("updated case: %s", JSON.stringify(updatedCase, null, 2));
   if (!er.hasErrors()) {
     if (updatedText) {
       await db.tx("update-case", t => {
@@ -246,16 +238,14 @@ async function postCaseUpdateHttp(req, res) {
     }
     // the client expects this request to respond with json
     // save successful response
-    // console.log("Params for returning case: %s", JSON.stringify(params));
     const freshArticle = await getCase(params, res);
-    // console.log("fresh article: %s", JSON.stringify(freshArticle, null, 2));
     res.status(200).json({
       OK: true,
       article: freshArticle
     });
     refreshSearch();
   } else {
-    console.error("Reporting errors: %s", er.errors);
+    logError(`400 with errors: ${er.errors.join(", ")}`);
     res.status(400).json({
       OK: false,
       errors: er.errors
@@ -314,10 +304,6 @@ async function getCaseHttp(req, res) {
   const article = await getCase(params, res);
   const staticText = await getEditStaticText(params);
   returnByType(res, params, article, staticText, req.user);
-}
-
-function print(name, obj) {
-  console.log("%s: %s", name, JSON.stringify(obj, null, 2));
 }
 
 async function getEditStaticText(params) {

--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -40,7 +40,7 @@ async function getEditStaticText(params) {
   try {
     staticText.authors = listUsers();
   } catch (e) {
-    console.error("Error reading users");
+    logError("Error reading users in controllers/method.js getEditStaticText");
   }
 
   staticText = Object.assign({}, staticText, sharedFieldOptions);
@@ -139,7 +139,7 @@ async function getMethod(params, res) {
   } catch (error) {
     // only log actual excaptional results, not just data not found
     if (error.message !== "No data returned from the query.") {
-      logError(error, { errorMessage: "No entry found", params: params });
+      logError(error);
     }
     // if no entry is found, render the 404 page
     return res.status(404).render("404");
@@ -158,27 +158,20 @@ async function postMethodUpdateHttp(req, res) {
     newMethod.post_date = Date.now();
   }
 
-  // console.log(
-  //   "Received tools_techniques_types from client: >>> \n%s\n",
-  //   JSON.stringify(newMethod.tools_techniques_types, null, 2)
-  // );
   // save any changes to the user-submitted text
   const {
     updatedText,
     author,
     oldArticle: oldMethod
   } = await maybeUpdateUserText(req, res, "method");
-  // console.log("updatedText: %s", JSON.stringify(updatedText));
-  // console.log("author: %s", JSON.stringify(author));
+
   const [updatedMethod, er] = getUpdatedMethod(
     user,
     params,
     newMethod,
     oldMethod
   );
-  // console.log("new method: \n%s", JSON.stringify(newMethod, null, 2));
-  // console.log("old method: \n%s", JSON.stringify(oldMethod, null, 2));
-  // console.log("updated method : \n%s", JSON.stringify(updatedMethod, null, 2));
+
   if (!er.hasErrors()) {
     if (updatedText) {
       await db.tx("update-method", t => {
@@ -198,19 +191,14 @@ async function postMethodUpdateHttp(req, res) {
     }
     // the client expects this request to respond with json
     // save successful response
-    // console.log("Params for returning method: %s", JSON.stringify(params));
     const freshArticle = await getMethod(params, res);
-    // console.log("fresh article: %s", JSON.stringify(freshArticle, null, 2));
     res.status(200).json({
       OK: true,
       article: freshArticle
     });
     refreshSearch();
   } else {
-    logError(er, {
-      req,
-      errorMessage: er.errors
-    });
+    logError(er);
     res.status(400).json({
       OK: false,
       errors: er.errors

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -192,7 +192,7 @@ async function postOrganizationUpdateHttp(req, res) {
     });
     refreshSearch();
   } else {
-    console.error("Reporting errors: %s", er.errors);
+    logError(`400 with errors: ${er.errors.join(", ")}`);
     res.status(400).json({
       OK: false,
       errors: er.errors

--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -10,10 +10,7 @@ const options = {
   capSQL: true // when building SQL queries dynamically, capitalize SQL keywords
 };
 const fs = require("fs");
-//if (process.env.LOG_QUERY === "true") {
-// options.query = evt => (process.env.LAST_QUERY = evt.query);
-// options.query = evt => console.log("QUERY: %s", evt.query);
-//}
+
 const pgp = require("pg-promise")(options);
 const path = require("path");
 const connectionString = process.env.DATABASE_URL;
@@ -79,7 +76,7 @@ function ErrorReporter() {
         return fn(...args);
       } catch (e) {
         self.errors.push(e.message);
-        console.error("Capturing error to report to client: " + e.message);
+        logError(`ErrorReporter: ${e.message}`);
         return e.message;
       }
     };
@@ -105,14 +102,13 @@ async function _listUsers() {
     "SELECT to_json(array_agg((id, name)::object_title)) AS authors FROM users;"
   )).authors;
   setTimeout(_listUsers, randomDelay());
-  // console.log("user cache refreshed");
 }
 
 async function _listCases(lang) {
   try {
     _cases[lang] = await db.many(LIST_ARTICLES, { type: "cases", lang: lang });
   } catch (e) {
-    console.error("Error in _listCases: %s", e.message);
+    logError(`Error in _listCases: ${e.message}`);
   }
   setTimeout(_listCases, randomDelay(), lang);
 }
@@ -267,7 +263,7 @@ function asUrl(value) {
     return escapedText("");
   }
   if (isObject(value)) {
-    console.error("Expecting URL, received: %s", value);
+    logError(`Expecting URL, received: ${value}`);
     throw new Error("Not a URL: " + value);
     return escapedText("");
   }
@@ -278,7 +274,7 @@ function asUrl(value) {
     // return new URL(value).href;
     return escapedText(new URL(value).href);
   } catch (e) {
-    console.error("Expected URL, received: %s", JSON.stringify(value));
+    logError(`Expecting URL, received: ${value}`);
     throw e;
   }
 }
@@ -352,11 +348,7 @@ function casekeys(objList, group) {
       uniq((objList || []).map(k => casekey(k, group)).filter(x => !!x)) || "{}"
     );
   } catch (e) {
-    console.error(
-      "Attempting to convert and filter a list of keys for %s, but got %s for the list",
-      group,
-      JSON.stringify(objList)
-    );
+    logError(`Error attempting to convert and filter a list of keys for ${group}`);
     throw e;
   }
 }

--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -114,19 +114,6 @@ Set.prototype.difference = function(setB) {
   return difference;
 };
 
-function compareItems(a, b) {
-  const aKeys = new Set(Object.keys(a));
-  const bKeys = new Set(Object.keys(b));
-  const keysNotInA = bKeys.difference(aKeys);
-  if (keysNotInA.size) {
-    console.error("Keys in update not found in original: %o", keysNotInA);
-  }
-  const keysNotInB = aKeys.difference(bKeys);
-  if (keysNotInB.size) {
-    console.error("Keys in original not found in update: %o", keysNotInB);
-  }
-}
-
 const supportedTypes = ["case", "method", "organization"];
 
 /** uniq ::: return a list with no repeated items. Items will be in the order they first appear in the list. **/

--- a/app.js
+++ b/app.js
@@ -286,7 +286,7 @@ app.get("/robots.txt", function(req, res, next) {
 // 404 error handling
 // this should always be after all routes to catch all invalid urls
 app.use((req, res, next) => {
-  console.log("failed request from %s", req.headers["user-agent"]);
+  logError(`404 failed request from ${req.headers["user-agent"]}`);
   res.status(404).render("404");
 });
 
@@ -303,13 +303,7 @@ if (process.env.NODE_ENV === "development") {
 
 // Better logging of "unhandled" promise exceptions
 process.on("unhandledRejection", function(reason, p) {
-  console.warn(
-    "Possibly Unhandled Rejection at: Promise ",
-    p,
-    " reason: ",
-    reason
-  );
-  // application specific logging here
+  logError(`Possibly Unhandled Rejection at: Promise for reason ${reason}`)
 });
 
 module.exports = app;


### PR DESCRIPTION
log errors to sentry instead of using console.error, and remove commented out console statements in article flow