### PR TITLE
catch NaN properly and also end response after 404

### DIFF
--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -312,6 +312,10 @@ async function getCaseHttp(req, res) {
   /* This is the entry point for getting an article */
   const params = parseGetParams(req, "case");
   const article = await getCase(params, res);
+  if (!article) {
+    res.status(404).render("404");
+    return null;
+  }
   const staticText = await getEditStaticText(params);
   returnByType(res, params, article, staticText, req.user);
 }
@@ -349,10 +353,6 @@ async function getCaseNewHttp(req, res) {
   const params = parseGetParams(req, "case");
   params.view = "edit";
   const article = CASE_STRUCTURE;
-  if (!article) {
-    res.status(404).render("404");
-    return null;
-  }
   const staticText = await getEditStaticText(params);
   returnByType(res, params, article, staticText, req.user);
 }

--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -292,7 +292,7 @@ async function postCaseUpdateHttp(req, res) {
 async function getCase(params, res) {
   try {
     if (Number.isNaN(params.articleid)) {
-      return res.status(404).render("404");
+      return null;
     }
     const articleRow = await db.one(CASE_BY_ID, params);
     const article = articleRow.results;
@@ -304,7 +304,7 @@ async function getCase(params, res) {
       logError(error, { errorMessage: "No entry found", params: params });
     }
     // if no entry is found, render the 404 page
-    return res.status(404).render("404");
+    return null;
   }
 }
 
@@ -337,6 +337,10 @@ async function getCaseEditHttp(req, res) {
   const params = parseGetParams(req, "case");
   params.view = "edit";
   const article = await getCase(params, res);
+  if (!article) {
+    res.status(404).render("404");
+    return null;
+  }
   const staticText = await getEditStaticText(params);
   returnByType(res, params, article, staticText, req.user);
 }
@@ -345,6 +349,10 @@ async function getCaseNewHttp(req, res) {
   const params = parseGetParams(req, "case");
   params.view = "edit";
   const article = CASE_STRUCTURE;
+  if (!article) {
+    res.status(404).render("404");
+    return null;
+  }
   const staticText = await getEditStaticText(params);
   returnByType(res, params, article, staticText, req.user);
 }

--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -130,7 +130,7 @@ async function postMethodNewHttp(req, res) {
 async function getMethod(params, res) {
   try {
     if (Number.isNaN(params.articleid)) {
-      return res.status(404).render("404");
+      return null;
     }
     const articleRow = await db.one(METHOD_BY_ID, params);
     const article = articleRow.results;
@@ -142,7 +142,7 @@ async function getMethod(params, res) {
       logError(error, { errorMessage: "No entry found", params: params });
     }
     // if no entry is found, render the 404 page
-    return res.status(404).render("404");
+    return null;
   }
 }
 
@@ -264,6 +264,10 @@ async function getMethodHttp(req, res) {
   /* This is the entry point for getting an article */
   const params = parseGetParams(req, "method");
   const article = await getMethod(params, res);
+  if (!article) {
+    res.status(404).render("404");
+    return null;
+  }
   const staticText = {};
   returnByType(res, params, article, staticText, req.user);
 }
@@ -272,6 +276,10 @@ async function getMethodEditHttp(req, res) {
   const params = parseGetParams(req, "method");
   params.view = "edit";
   const article = await getMethod(params, res);
+  if (!article) {
+    res.status(404).render("404");
+    return null;
+  }
   const staticText = await getEditStaticText(params);
   returnByType(res, params, article, staticText, req.user);
 }

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -129,7 +129,7 @@ async function postOrganizationNewHttp(req, res) {
 async function getOrganization(params, res) {
   try {
     if (Number.isNaN(params.articleid)) {
-      return res.status(404).render("404");
+      return null;
     }
     const articleRow = await db.one(ORGANIZATION_BY_ID, params);
     const article = articleRow.results;
@@ -141,7 +141,7 @@ async function getOrganization(params, res) {
       logError(error, { errorMessage: "No entry found", params: params });
     }
     // if no entry is found, render the 404 page
-    return res.status(404).render("404");
+    return null;
   }
 }
 
@@ -255,6 +255,10 @@ async function getOrganizationHttp(req, res) {
   const params = parseGetParams(req, "organization");
 
   const article = await getOrganization(params, res);
+  if (!article) {
+    res.status(404).render("404");
+    return null;
+  }
   const staticText = {};
   returnByType(res, params, article, staticText, req.user);
 }
@@ -263,6 +267,10 @@ async function getOrganizationEditHttp(req, res) {
   const params = parseGetParams(req, "organization");
   params.view = "edit";
   const article = await getOrganization(params, res);
+  if (!article) {
+    res.status(404).render("404");
+    return null;
+  }
   const staticText = await getEditStaticText(params);
   returnByType(res, params, article, staticText, req.user);
 }

--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -201,6 +201,10 @@ function number(value) {
   if (value === "") {
     return null;
   }
+  let numValue = Number(value);
+  if (Number.isNaN(numValue)) {
+    return numValue;
+  }
   return pgp.as.number(Number(value));
 }
 
@@ -208,14 +212,11 @@ function integer(value) {
   if (value === "") {
     return null;
   }
-  if (value === "NaN") {
-    throw new Error('Expected integer, got "NaN" as a string');
+  let intValue = parseInt(value, 10);
+  if (Number.isNaN(intValue)) {
+    return intValue;
   }
-  let retVal = pgp.as.number(parseInt(value, 10));
-  if (Number.isNaN(retVal)) {
-    throw new Error("Expected integer value, got " + value);
-  }
-  return retVal;
+  return pgp.as.number(intValue);
 }
 
 function asFloat(value) {

--- a/api/helpers/log-error.js
+++ b/api/helpers/log-error.js
@@ -1,6 +1,7 @@
 const Sentry = require("@sentry/node");
 
-const isProdOrStaging = process.env.NODE_ENV === "production" || process.env.NODE_ENV === "staging";
+const isProdOrStaging =
+  process.env.NODE_ENV === "production" || process.env.NODE_ENV === "staging";
 
 function logError(error, params = {}) {
   if (isProdOrStaging) {
@@ -9,6 +10,8 @@ function logError(error, params = {}) {
     } else {
       Sentry.captureException(error);
     }
+  } else {
+    console.error(error, params);
   }
 }
 

--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -95,7 +95,7 @@ const returnByType = (res, params, article, static, user) => {
 };
 
 const parseGetParams = function(req, type) {
-  let parms = Object.assign({}, req.query, {
+  return Object.assign({}, req.query, {
     type,
     view: as.value(req.params.view || "view"),
     articleid: as.integer(req.params.thingid || req.params.articleid),
@@ -103,7 +103,6 @@ const parseGetParams = function(req, type) {
     userid: req.user ? as.integer(req.user.id) : null,
     returns: as.value(req.query.returns || "html")
   });
-  return parms;
 };
 
 /* I can't believe basic set operations are not part of ES5 Sets */

--- a/api/helpers/things.js
+++ b/api/helpers/things.js
@@ -95,14 +95,15 @@ const returnByType = (res, params, article, static, user) => {
 };
 
 const parseGetParams = function(req, type) {
-  return Object.assign({}, req.query, {
+  let parms = Object.assign({}, req.query, {
     type,
     view: as.value(req.params.view || "view"),
-    articleid: as.number(req.params.thingid || req.params.articleid),
+    articleid: as.integer(req.params.thingid || req.params.articleid),
     lang: as.value(getLanguage(req)),
-    userid: req.user ? as.number(req.user.id) : null,
+    userid: req.user ? as.integer(req.user.id) : null,
     returns: as.value(req.query.returns || "html")
   });
+  return parms;
 };
 
 /* I can't believe basic set operations are not part of ES5 Sets */


### PR DESCRIPTION
Fixes #745 

1. Much more robust checks for NaN (and in the right place this time!)
2. Log to console on from `logMessage` when on localhost
3. End response at 404 without trying to write further data to it.