### PR TITLE
error logging: remove 404 logging to sentry

### DIFF
--- a/api/controllers/bookmark.js
+++ b/api/controllers/bookmark.js
@@ -44,7 +44,7 @@ async function lookupBookmarksById(req, res, userId) {
       message: "Retrieved ALL bookmarks for specified user"
     });
   } catch (error) {
-    logError(error, { errorMessage: "Exception in lookupBookmarksById" });
+    logError(error);
     res.json({ success: false, error: error.message || error });
   }
 }
@@ -58,7 +58,7 @@ async function queryBookmarks(req, res) {
     }
     lookupBookmarksById(req, res, userid);
   } catch (error) {
-    logError(error, { errorMessage: "Exception in queryBookmarks" });
+    logError(error);
     res.json({ success: false, error: error.message || error });
   }
 }
@@ -94,20 +94,14 @@ router.get("/list/:userid", queryBookmarks);
 router.post("/add", async function addBookmark(req, res) {
   try {
     if (!req.body.bookmarkType) {
-      logError(error, {
-        req,
-        errorMessage: "Required parameter (bookmarkType) wasn't specified"
-      });
+      logError("/bookmark/add - Required parameter (bookmarkType) wasn't specified");
       res.status(400).json({
         message: "Required parameter (bookmarkType) wasn't specified"
       });
       return;
     }
     if (!req.body.thingid) {
-      logError(error, {
-        req,
-        errorMessage: "Required parameter (thingid) wasn't specified"
-      });
+      logError("/bookmark/add - Required parameter (thingid) wasn't specified");
       res
         .status(400)
         .json({ error: "Required parameter (thingid) wasn't specified" });

--- a/api/controllers/case.js
+++ b/api/controllers/case.js
@@ -87,7 +87,7 @@ async function postCaseNewHttp(req, res) {
     req.params.thingid = thing.thingid;
     await postCaseUpdateHttp(req, res);
   } catch (error) {
-    logError(error, { errorMessage: "Exception in postCaseNewHttp" });
+    logError(error);
     res.status(400).json({ OK: false, error: error });
   }
 }
@@ -291,7 +291,7 @@ async function getCase(params, res) {
   } catch (error) {
     // only log actual excaptional results, not just data not found
     if (error.message !== "No data returned from the query.") {
-      logError(error, { errorMessage: "No entry found", params: params });
+      logError(error);
     }
     // if no entry is found, render the 404 page
     return null;

--- a/api/controllers/method.js
+++ b/api/controllers/method.js
@@ -96,7 +96,7 @@ async function postMethodNewHttp(req, res) {
     req.params.thingid = thing.thingid;
     await postMethodUpdateHttp(req, res);
   } catch (error) {
-    logError(error, { errorMessage: "Exception in postMethodNewHttp" });
+    logError(error);
     res.status(400).json({ OK: false, error: error });
   }
 }

--- a/api/controllers/organization.js
+++ b/api/controllers/organization.js
@@ -95,7 +95,7 @@ async function postOrganizationNewHttp(req, res) {
     req.params.thingid = thing.thingid;
     await postOrganizationUpdateHttp(req, res);
   } catch (error) {
-    logError(error, { errorMessage: "Exception in postOrganizationNewHttp" });
+    logError(error);
     return res.status(400).json({ OK: false, error: error });
   }
 }
@@ -138,7 +138,7 @@ async function getOrganization(params, res) {
   } catch (error) {
     // only log actual excaptional results, not just data not found
     if (error.message !== "No data returned from the query.") {
-      logError(error, { errorMessage: "No entry found", params: params });
+      logError(error);
     }
     // if no entry is found, render the 404 page
     return null;

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -75,10 +75,7 @@ router.get("/getAllForType", async function getAllForType(req, res) {
     });
     res.status(200).json(jtitlelist);
   } catch (error) {
-    logError(error, {
-      req,
-      errorMessage: "Exception in GET /search/getAllForType"
-    });
+    logError(error);
     res.status(500).json({ error: error });
   }
 });

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -157,7 +157,6 @@ router.get("/", async function(req, res) {
     }
     return getUserById(req.user.user_id, req, res);
   } catch (error) {
-    console.error("Exception in /user/ => %s", error.message);
     logError(error);
   }
 });
@@ -208,12 +207,11 @@ router.post("/", async function(req, res) {
     });
     res.status(200).json({ OK: true, user: { id: user.id } });
   } catch (error) {
-    logError(error);
     if (error.message && error.message == "No data returned from the query.") {
       res.status(404).json({ OK: false });
     } else {
+      logError(error);
       res.status(500).json({ OK: false, error: error });
-      console.error("Exception in POST /user => %s", error.message);
     }
   }
 });

--- a/app.js
+++ b/app.js
@@ -286,7 +286,6 @@ app.get("/robots.txt", function(req, res, next) {
 // 404 error handling
 // this should always be after all routes to catch all invalid urls
 app.use((req, res, next) => {
-  logError(`404 failed request from ${req.headers["user-agent"]}`);
   res.status(404).render("404");
 });
 


### PR DESCRIPTION
- also remove params from `logError` call since we don't send those to sentry