### PR TITLE
edit forms: show more options in dropdown list

### DIFF
--- a/public/css/slim-select.css
+++ b/public/css/slim-select.css
@@ -251,7 +251,7 @@
     .ss-main .ss-content .ss-addable {
       padding-top: 0px; }
     .ss-main .ss-content .ss-list {
-      max-height: 200px;
+      max-height: 360px;
       overflow-x: hidden;
       overflow-y: auto;
       text-align: left; }


### PR DESCRIPTION
with this change we should be able to see 8-10 options (depending on if any wrap on to multiple lines)

before:
<img width="742" alt="Screenshot 2019-09-11 13 34 26" src="https://user-images.githubusercontent.com/130878/64733146-088c2d80-d499-11e9-82f9-3c646d5cad5c.png">

after:
<img width="741" alt="Screenshot 2019-09-11 13 34 16" src="https://user-images.githubusercontent.com/130878/64733098-ef837c80-d498-11e9-8f2b-3052153f7516.png">

@jesicarson @scottofletcher 