### PR TITLE
override page NaN to be page 1

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -41,6 +41,9 @@ router.get("/getAllForType", async function getAllForType(req, res) {
   try {
     let objType = req.query.objType.toLowerCase();
     let page = Math.max(parseInt(req.query.page || 1), 1);
+    if (Number.isNaN(page)) {
+      page = 1;
+    }
     let offset = 0;
     let response_limit = Number.MAX_SAFE_INTEGER;
     if (!req.query.response_limit) {


### PR DESCRIPTION
If the user passes in bogus data for a case id, we return a 404, but if there is bogus data for a page number, I just return page 1. If that seems like a bad call we can switch it to be a 404 instead.

Fixes #759 

Sentry alert this addresses: https://sentry.io/organizations/participedia-sentry-errors/issues/1158686160/?project=1524525&query=is%3Aunresolved&statsPeriod=14d