### PR TITLE
fix image upload bug related to image caption/title field

### DIFF
--- a/api/helpers/db.js
+++ b/api/helpers/db.js
@@ -17,6 +17,7 @@ const connectionString = process.env.DATABASE_URL;
 const parse = require("pg-connection-string").parse;
 let config;
 const uploadToAWS = require("./upload-to-aws.js");
+const logError = require("./log-error.js");
 
 try {
   config = parse(connectionString);
@@ -394,7 +395,7 @@ function aSourcedMedia(obj) {
   let url = obj.url;
   // some types of sourced media are links, anything already a link does not need to be uploaded
   if (!obj.url.startsWith("http")) {
-    obj.url = uploadToAWS(obj.url, obj.title);
+    obj.url = uploadToAWS(obj.url);
   }
   return new FullFile(obj);
 }

--- a/api/helpers/upload-to-aws.js
+++ b/api/helpers/upload-to-aws.js
@@ -1,10 +1,11 @@
 const AWS = require("aws-sdk");
 const uuidv4 = require("uuid/v4");
+const logError = require("./log-error.js");
 
 AWS.config.update({ region: process.env.AWS_REGION });
 
-function uploadToAWS(base64String, fileName) {
-  const newFileName = uuidv4() + "-" + fileName;
+function uploadToAWS(base64String) {
+  const newFileName = uuidv4();
   const s3 = new AWS.S3({ apiVersion: "2006-03-01" });
   const base64Data = Buffer.from(
     base64String.split(";")[1].split(",")[1],
@@ -23,8 +24,9 @@ function uploadToAWS(base64String, fileName) {
   };
 
   s3.upload(uploadParams, (err, data) => {
-    if (err) console.log("Error", err);
-    // if (data) console.log("success");
+    if (err) {
+      logError(err);
+    }
   });
 
   return `${process.env.AWS_UPLOADS_URL}${newFileName}`;

--- a/app.js
+++ b/app.js
@@ -34,6 +34,9 @@ if (
   app.use(Sentry.Handlers.requestHandler());
 }
 
+// other logging middlewear
+app.use(morgan("dev")); // request logging
+
 // Actual Participedia APIS vs. Nodejs gunk
 const handlebarsHelpers = require("./api/helpers/handlebars-helpers.js");
 const { case_ } = require("./api/controllers/case");
@@ -291,9 +294,6 @@ app.use((req, res, next) => {
 
 // The error handler must be before any other logging middleware and after all controllers
 app.use(Sentry.Handlers.errorHandler());
-
-// other logging middlewear
-app.use(morgan("dev")); // request logging
 
 if (process.env.NODE_ENV === "development") {
   // only use in development


### PR DESCRIPTION
we were using the image caption in the image file name but not escaping illegal characters, so an image uploaded with a `%` in the caption caused the image to not be uploaded or displayed properly. 

i fixed this by not using the file caption for the new file name.

i also fixed an issue with the morgan logging middlewear not logging to the terminal because it was too far down the call stack in app.js.

fixes: https://github.com/participedia/usersnaps/issues/875