### PR TITLE
Reader view image sizing

### DIFF
--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -543,8 +543,8 @@ module.exports = {
     return article.photos && article.photos.length > 0;
   },
 
-  hasCaptionText(article) {
-    return article.title || article.source_url || article.attribution;
+  hasCaptionText(photo) {
+    return photo.title || photo.source_url || photo.attribution;
   },
 
   getFirstPhotoUrl(article) {

--- a/public/css/view-slideshow.css
+++ b/public/css/view-slideshow.css
@@ -203,52 +203,35 @@ html.is-flickity-fullscreen {
 
 .carousel-cell {
   width: 100%;
-  height: 300px;
+  height: 350px;
   margin-right: 10px;
   /* center images in cells with flexbox */
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #ececec;
+  background-color: rgba(0,0,0,.2);
 }
 
 .carousel.is-fullscreen .carousel-cell {
   height: 100%;
 }
 
-.carousel-cell-image {
-  display: block;
-  max-height: 100%;
+.carousel-cell-image-container {
+  width: 100%;
+  height: 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
 }
 
-.carousel-nav {
-  background-color: #fff;
-  margin-top: 20px;
-  margin-bottom: 40px;
-  padding: 4px 0;
-}
-.carousel-nav .carousel-cell {
-  width: 100px;
-  height: 100px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid #fff;
-}
-.carousel-nav .carousel-cell-image {
-  width: 100px;
-}
-
-.carousel.is-fullscreen .carousel-cell-image {
-  max-width: 100%;
+.carousel.is-fullscreen .carousel-cell-image-container {
+  max-height: 75%;
+  max-width: 75%;
+  background-size: unset;
 }
 
 .flickity-enabled.is-fullscreen {
   z-index: 2;
-}
-
-.carousel-nav .carousel-cell.is-nav-selected {
-  border: 1px solid red;
 }
 
 .flickity-button, .flickity-button:hover {

--- a/public/css/view-slideshow.css
+++ b/public/css/view-slideshow.css
@@ -202,8 +202,9 @@ html.is-flickity-fullscreen {
 }
 
 .carousel-cell {
+  position: relative;
   width: 100%;
-  height: 350px;
+  padding-top: 56.25%; /* 16:9 Aspect Ratio */
   margin-right: 10px;
   /* center images in cells with flexbox */
   display: flex;
@@ -213,10 +214,16 @@ html.is-flickity-fullscreen {
 }
 
 .carousel.is-fullscreen .carousel-cell {
+  padding-top: 0;
   height: 100%;
 }
 
 .carousel-cell-image-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   width: 100%;
   height: 100%;
   background-position: center;
@@ -225,9 +232,9 @@ html.is-flickity-fullscreen {
 }
 
 .carousel.is-fullscreen .carousel-cell-image-container {
-  max-height: 75%;
-  max-width: 75%;
-  background-size: unset;
+  max-height: 100%;
+  max-width: 100%;
+  background-size: 50%;
 }
 
 .flickity-enabled.is-fullscreen {
@@ -247,7 +254,7 @@ html.is-flickity-fullscreen {
   opacity: 0;
   transition: opacity .25s ease-in-out;
 }
-.carousel-cell:hover .carousel-cell-image-title {
+.carousel-cell-has-image-title:hover .carousel-cell-image-title {
   opacity: 1;
 }
 .carousel-cell-image-title span {

--- a/public/css/view-slideshow.css
+++ b/public/css/view-slideshow.css
@@ -198,6 +198,7 @@ html.is-flickity-fullscreen {
 /* CUSTOM FLICKITY STYLES */
 .carousel {
   background: #fff;
+  margin-bottom: 40px;
 }
 
 .carousel-cell {
@@ -208,6 +209,7 @@ html.is-flickity-fullscreen {
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: #ececec;
 }
 
 .carousel.is-fullscreen .carousel-cell {

--- a/views/partials/view-slideshow.html
+++ b/views/partials/view-slideshow.html
@@ -31,15 +31,4 @@
       </div>
     {{/each}}
   </div>
-
-  <div
-    class="carousel carousel-nav"
-    data-flickity='{ "asNavFor": ".carousel-main", "contain": true, "pageDots": false, "wrapAround": true }'
-  >
-    {{#each article.photos}}
-      <div class="carousel-cell">
-        <img class="carousel-cell-image" src="{{url}}" alt="{{title}}" />
-      </div>
-    {{/each}}
-  </div>
 {{/if}}

--- a/views/partials/view-slideshow.html
+++ b/views/partials/view-slideshow.html
@@ -4,9 +4,9 @@
     data-flickity='{ "wrapAround": true, "contain": true, "pageDots": false, "fullscreen": true, "lazyLoad": 1 }'
   >
     {{#each article.photos}}
-      <div class="carousel-cell">
-        <div class="carousel-cell-image-container" style="background-image: url({{url}})"></div>
-        {{#if (hasCaptionText ../article)}}
+      <div class="carousel-cell {{#if (hasCaptionText this)}}carousel-cell-has-image-title{{/if}}">
+        <div class="carousel-cell-image-container " style="background-image: url({{url}})"></div>
+        {{#if (hasCaptionText this)}}
           <div class="carousel-cell-image-title">
             <span>
               {{#if source_url}}

--- a/views/partials/view-slideshow.html
+++ b/views/partials/view-slideshow.html
@@ -5,11 +5,7 @@
   >
     {{#each article.photos}}
       <div class="carousel-cell">
-        <img
-          class="carousel-cell-image"
-          data-flickity-lazyload="{{url}}"
-          alt="{{title}}"
-        />
+        <div class="carousel-cell-image-container" style="background-image: url({{url}})"></div>
         {{#if (hasCaptionText ../article)}}
           <div class="carousel-cell-image-title">
             <span>


### PR DESCRIPTION
- set images to fill image container and set container size to 16:9 aspect ratio
- only show background/overlay for caption on hover if caption exists

<img width="1680" alt="Screenshot 2019-12-03 10 48 52" src="https://user-images.githubusercontent.com/130878/70080123-d9c6b480-15ba-11ea-8f3a-d3a778269e33.png">

@jesicarson 

fixes: https://github.com/participedia/api/issues/791