### PR TITLE
remove language select placeholder if we are only showing the language codes

### DIFF
--- a/views/partials/language-select.html
+++ b/views/partials/language-select.html
@@ -1,5 +1,8 @@
 <select name="locale" class="language-select js-language-select">
-  <option value="">{{t "Select Language"}}</option>
+  {{#if showTwoLetterCode}}
+  {{else}}
+    <option value="">{{t "Select Language"}}</option>
+  {{/if}}
   {{#each (getLanguageOptions)}}
     {{#if ../showTwoLetterCode}}
       {{> language-select-option key=twoLetterCode value=(toUpperCase twoLetterCode)}}


### PR DESCRIPTION
remove language select placeholder if we are only showing the language codes
fixes: https://github.com/participedia/usersnaps/issues/951