### PR TITLE
Added S3 migration scripts for both the assets and the URL data in Postgres

### DIFF
--- a/scripts/copy-optimize-images-to-new-bucket.js
+++ b/scripts/copy-optimize-images-to-new-bucket.js
@@ -1,0 +1,196 @@
+const uploadToAWS = require("../api/helpers/upload-to-aws.js");
+const AWS = require("aws-sdk");
+const jimp = require('jimp');
+const async = require('async');
+const s3 = new AWS.S3({
+  apiVersion: "2006-03-01",
+  region: process.env.AWS_REGION,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+});
+
+let downloadedFileCount = 0, lastDownloadedFile, isMore = true;
+let oldBucket = "uploads.participedia.xyz";
+
+async.whilst(
+  () => {return isMore;},
+  cb => {
+    s3.listObjectsV2({
+      Bucket: oldBucket,
+      Delimiter: '/',
+      StartAfter: lastDownloadedFile
+    }, (err, assetsList) => {
+      async.eachSeries(assetsList.Contents, (asset, innerCb) => {
+        downloadedFileCount++;
+        lastDownloadedFile = asset.Key;
+        console.log(lastDownloadedFile);
+        console.log(downloadedFileCount);
+        s3.getObject({
+          Bucket: oldBucket,
+          Key: lastDownloadedFile
+        }, (err, object) => {
+          console.log(object.ContentType);
+
+          async.parallel([
+            uploadCb => { // Thumbnail upload
+              if (object.ContentType === "image/png" || object.ContentType === "image/jpg" || object.ContentType === "image/jpeg") {
+                // Resize images
+                jimp.read(object.Body, (err, img) => {
+                  if (err) {
+                    console.log(err);
+                    s3.copyObject({ // Cannot read, just copy
+                      Bucket: process.env.AWS_S3_BUCKET,
+                      CopySource: encodeURI(`${oldBucket}/${asset.Key}`),
+                      ContentType: object.ContentType,
+                      ACL: "public-read",
+                      MetadataDirective: "COPY",
+                      Key: asset.Key
+                    }, uploadCb);
+                  } else {
+                    if (img.bitmap.width > 600 || img.bitmap.height > 600) { // Resize required
+                      let resizeW = 600;
+                      let resizeH = jimp.AUTO;
+                      if (img.bitmap.width < img.bitmap.height) {
+                        resizeW = jimp.AUTO;
+                        resizeH = 600;
+                      }
+                      img
+                        .resize(resizeW, resizeH) // resize
+                        .quality(60) // set image quality
+                        .getBase64(object.ContentType, (err, imgData) => {
+                          if (err){
+                            uploadCb(err);
+                          } else {
+                            s3.upload({
+                              Bucket: process.env.AWS_S3_BUCKET,
+                              Key: `thumbnail/${asset.Key}`,
+                              Body: Buffer.from(imgData.replace(/^data:image\/\w+;base64,/, ""), "base64"),
+                              ContentEncoding: "base64",
+                              ContentType: object.ContentType,
+                              ACL: "public-read",
+                            }, (err, data) => {
+                              if (err) {
+                                uploadCb(err);
+                              } else {
+                                uploadCb();
+                              }
+                            });
+                          }
+                        });
+                    } else { // the image is too small to be resized, just upload to the new bucket
+                      img.getBase64(object.ContentType, (err, imgData) => {
+                        if(err){
+                          uploadCb(err);
+                        } else {
+                          s3.upload({
+                            Bucket: process.env.AWS_S3_BUCKET,
+                            Key: `thumbnail/${asset.Key}`,
+                            Body: Buffer.from(imgData.replace(/^data:image\/\w+;base64,/, ""), "base64"),
+                            ContentEncoding: "base64",
+                            ContentType: object.ContentType,
+                            ACL: "public-read",
+                          }, (err, data) => {
+                            if (err) {
+                              uploadCb(err);
+                            } else {
+                              uploadCb();
+                            }
+                          });
+                        }
+                      });
+                    }
+                  }
+                });
+              } else { // No need to upload thumbnail for anything else but images
+                uploadCb();
+              }
+            },
+            uploadCb => { // Full size image and other file types upload
+              if (object.ContentType === "image/png" || object.ContentType === "image/jpg" || object.ContentType === "image/jpeg") { // Optimize full size image
+                jimp.read(object.Body, (err, img) => {
+                  if (err) {
+                    console.log(err);
+                    s3.copyObject({ // Cannot read, just copy
+                      Bucket: process.env.AWS_S3_BUCKET,
+                      CopySource: encodeURI(`${oldBucket}/${asset.Key}`),
+                      ContentType: object.ContentType,
+                      ACL: "public-read",
+                      MetadataDirective: "COPY",
+                      Key: asset.Key
+                    }, uploadCb);
+                  } else {
+                    if (img.bitmap.width > 1600 || img.bitmap.height > 1600) { // Resize required
+                      let resizeW = 1600;
+                      let resizeH = jimp.AUTO;
+                      if (img.bitmap.width < img.bitmap.height) {
+                        resizeW = jimp.AUTO;
+                        resizeH = 1600;
+                      }
+                      img
+                        .resize(resizeW, resizeH) // resize
+                        .quality(60) // set image quality
+                        .getBase64(object.ContentType, (err, imgData) => {
+                          if (err) {
+                            uploadCb(err);
+                          } else {
+                            s3.upload({
+                              Bucket: process.env.AWS_S3_BUCKET,
+                              Key: asset.Key,
+                              Body: Buffer.from(imgData.replace(/^data:image\/\w+;base64,/, ""), "base64"),
+                              ContentEncoding: "base64",
+                              ContentType: object.ContentType,
+                              ACL: "public-read"
+                            }, uploadCb);
+                          }
+                        });
+                    } else { // the image is too small to be resized, just upload to the new bucket
+                      img.getBase64(object.ContentType, (err, imgData) => {
+                        if(err){
+                          uploadCb(err);
+                        } else {
+                          s3.upload({
+                            Bucket: process.env.AWS_S3_BUCKET,
+                            Key: asset.Key,
+                            Body: Buffer.from(imgData.replace(/^data:image\/\w+;base64,/, ""), "base64"),
+                            ContentEncoding: "base64",
+                            ContentType: object.ContentType,
+                            ACL: "public-read"
+                          }, uploadCb);
+                        }
+                      });
+                    }
+                  }
+                });
+              } else { // Copy over documents
+                s3.copyObject({
+                  Bucket: process.env.AWS_S3_BUCKET,
+                  CopySource: encodeURI(`${oldBucket}/${asset.Key}`),
+                  ContentType: object.ContentType,
+                  ACL: "public-read",
+                  MetadataDirective: "COPY",
+                  Key: asset.Key
+                }, uploadCb);
+              }
+            }
+          ], innerCb);
+        });
+      }, err => {
+        if(err) {
+          cb(err);
+        } else {
+          if(!assetsList.IsTruncated) {
+            isMore = false
+          }
+          cb();
+        }
+      });
+    });
+  },
+  (err) => {
+    if(err) throw err;
+  }
+);
+
+
+
+

--- a/scripts/points-url-data-to-new-bucket.js
+++ b/scripts/points-url-data-to-new-bucket.js
@@ -1,0 +1,92 @@
+const promise = require("bluebird");
+const options = {
+  // Initialization Options
+  promiseLib: promise, // use bluebird as promise library
+  capSQL: true, // when building SQL queries dynamically, capitalize SQL keywords
+};
+const pgp = require("pg-promise")(options);
+const connectionString = process.env.DATABASE_URL;
+const parse = require("pg-connection-string").parse;
+const oldS3Url = 'uploads.participedia.xyz';
+const newS3Url = process.env.AWS_S3_BUCKET;
+
+let config;
+try {
+  config = parse(connectionString);
+  if (process.env.NODE_ENV === "test" || config.host === "localhost") {
+    config.ssl = false;
+  } else {
+    config.ssl = true;
+  }
+} catch (e) {
+  console.error("# Error parsing DATABASE_URL environment variable");
+}
+
+let db = pgp(config);
+getPhotos('cases');
+getPhotos('methods');
+getPhotos('organizations');
+
+function getPhotos(table) {
+  db.any(`SELECT id, photos, files, videos, audio FROM ${table}`)
+  .then(function(data) {
+    data.forEach(data => {
+      // Handle photos
+      var newPhoto = data.photos;
+      var newFiles = data.files;
+      var newVideos = data.videos;
+      var newAudio = data.audio;
+      var metaData = {};
+
+      if (newPhoto.search(oldS3Url) >= 0) {
+        newPhoto = newPhoto.replace(oldS3Url, newS3Url);
+        metaData['photos'] = newPhoto;
+      } else {
+        // console.log(`Table: ${table}, Column 'photos', ID ${data.id} doesn't have the URL we are looking for.`);
+      }
+
+      if (newFiles.search(oldS3Url) >= 0) {
+        newFiles = newFiles.replace(oldS3Url, newS3Url);
+        metaData['files'] = newFiles;
+      } else {
+        // console.log(`Table: ${table}, Column 'files', ID ${data.id} doesn't have the URL we are looking for.`);
+      }
+
+      if (newVideos.search(oldS3Url) >= 0) {
+        newVideos = newVideos.replace(oldS3Url, newS3Url);
+        metaData['videos'] = newAudio;
+      } else {
+        // console.log(`Table: ${table}, Column 'videos', ID ${data.id} doesn't have the URL we are looking for.`);
+      }
+
+      if (newAudio.search(oldS3Url) >= 0) {
+        newAudio = newAudio.replace(oldS3Url, newS3Url);
+        metaData['audio'] = newAudio;
+      } else {
+        // console.log(`Table: ${table}, Column 'audio', ID ${data.id} doesn't have the URL we are looking for.`);
+      }
+
+
+      if (metaData.hasOwnProperty('photos') || metaData.hasOwnProperty('files') || metaData.hasOwnProperty('videos') || metaData.hasOwnProperty('audio')) {
+        updatePhoto(data.id, metaData, table);
+      }
+    });
+  })
+  .catch(function(error) {
+    console.log(error);
+  });
+}
+
+function updatePhoto(id, value, table) {
+  const dataSingle = value;
+  const condition = pgp.as.format(` WHERE id = ${id}`, dataSingle);
+  const update = pgp.helpers.update(dataSingle, null, table) + condition;
+  
+  db.none(update)
+  .then(function(data) {
+    console.log(`Table: ${table}; ID: ${id} updated`);
+  })
+  .catch(function(error) {
+    console.log(error);
+  });
+}


### PR DESCRIPTION
## Description
These 2 scripts are for copying over the assets from existing S3 to the new one. 

`scripts/copy-optimize-images-to-new-bucket.js` - Copy over the assets themselves. Resize, optimized and store them in the new bucket `participedia.{{stage || prod}}` according to `process.env.AWS_S3_BUCKET` environment variable.

`scripts/points-url-data-to-new-bucket.js` - Changes the stored URLs in the database from `uploads.participedia.xyz` to `process.env.AWS_S3_BUCKET`. This is to points the existing images data to the new bucket.

## Context/Issue Link
https://github.com/participedia/api/issues/811


## How has this been tested? How can it be tested?
Tested locally and stage

## Screenshots (if it's a frontend change)
