### PR TITLE
fix image rendering bug on home/search and reader pages

### DIFF
--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -410,11 +410,15 @@ module.exports = {
   getFirstImageForArticle: article => {
     if (article.photos && article.photos.length > 0) {
       // search pages return photos for articles in this format
-      return article.photos[0].url;
+      return encodeURI(article.photos[0].url);
     } else if (article.images && article.images.length > 0) {
       // user profile pages return photos for articles in this format
-      return article.images[0];
+      return encodeURI(article.images[0]);
     }
+  },
+
+  encodeURI: (url) => {
+    return encodeURI(url);
   },
 
   isEmptyArray: (article, name) => {

--- a/views/partials/article-card.html
+++ b/views/partials/article-card.html
@@ -10,7 +10,7 @@
     <div
       class="article-card-img js-article-card-img lazyload"
       data-bg="{{getFirstImageForArticle this}}"
-      style="background-image: url('/images/1x1-transparent.png');"
+      style="background-image: url('/images/texture_1.svg');"
     ></div>
 
     <div class="article-card-content">

--- a/views/partials/article-card.html
+++ b/views/partials/article-card.html
@@ -10,7 +10,7 @@
     <div
       class="article-card-img js-article-card-img lazyload"
       data-bg="{{getFirstImageForArticle this}}"
-      style="background-image: url('/images/texture_1.svg');"
+      style="background-image: url('/images/1x1-transparent.png');"
     ></div>
 
     <div class="article-card-content">

--- a/views/partials/view-slideshow.html
+++ b/views/partials/view-slideshow.html
@@ -5,7 +5,7 @@
   >
     {{#each article.photos}}
       <div class="carousel-cell {{#if (hasCaptionText this)}}carousel-cell-has-image-title{{/if}}">
-        <div class="carousel-cell-image-container " style="background-image: url({{url}})"></div>
+        <div class="carousel-cell-image-container " style="background-image: url({{encodeURI url}})"></div>
         {{#if (hasCaptionText this)}}
           <div class="carousel-cell-image-title">
             <span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- use `encodeURI` to fix urls with spaces in them

## Context/Issue Link
- https://github.com/participedia/usersnaps/issues/977
- https://github.com/participedia/usersnaps/issues/975
- https://github.com/participedia/usersnaps/issues/973

## How has this been tested? How can it be tested?
- copied an offending image url to my localdb to verify the issue and test the fix
- tested locally on the home/search page and on entry reader pages

