### PR TITLE
fix twitter share link bug

### DIFF
--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -411,7 +411,10 @@ module.exports = {
     if (article.photos && article.photos.length > 0) {
       // search pages return photos for articles in this format
       let fullUrl = article.photos[0].url;
-      let thumbnailUrl = fullUrl.replace(process.env.AWS_UPLOADS_URL, `${process.env.AWS_UPLOADS_URL}thumbnail/`);
+      let thumbnailUrl = fullUrl.replace(
+        process.env.AWS_UPLOADS_URL,
+        `${process.env.AWS_UPLOADS_URL}thumbnail/`
+      );
       return thumbnailUrl;
     } else if (article.images && article.images.length > 0) {
       // user profile pages return photos for articles in this format
@@ -419,7 +422,7 @@ module.exports = {
     }
   },
 
-  encodeURI: (url) => {
+  encodeURI: url => {
     return encodeURI(url);
   },
 

--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -650,7 +650,9 @@ module.exports = {
     const title = article.title;
     const shareUrls = {
       facebook: `https://www.facebook.com/sharer/sharer.php?u=${url}`,
-      twitter: `https://twitter.com/intent/tweet?text=Participedia: ${title} - ${url}`,
+      twitter: `https://twitter.com/intent/tweet?text=.@participedia: ${encodeURIComponent(
+        title
+      )}&url=${url}`,
       linkedIn: `https://www.linkedin.com/shareArticle?mini=true&url=${url}&title=${title}`,
     };
     return shareUrls[type];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fixes issue with twitter share links when there is a `&` in the article title
- fixes some formatting in handlebars-helpers.js after running prettier

## Issue Link
https://github.com/participedia/usersnaps/issues/986

## How has this been tested? How can it be tested?
- tested locally with titles with `&` symbols, will test on staging as well

## Screenshots (if it's a frontend change)
<img width="1680" alt="Screen Shot 2020-02-10 at 2 42 56 PM" src="https://user-images.githubusercontent.com/130878/74197150-a6844f80-4c13-11ea-98de-d23d3dc438e8.png">

