### PR TITLE
Update twitter share text

### DIFF
--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -649,7 +649,7 @@ module.exports = {
   },
 
   shareLink(type, article, req) {
-    const twitterCharacterMax = 240 - 17; // minus 17 characters to account for @participedia and elipsis
+    const twitterCharacterMax = 240 - 17; // minus 17 characters to account for @participedia and ellipsis
     const url = currentUrl(req);
     const title = () => {
       const articleTitle = article.title;

--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -649,14 +649,24 @@ module.exports = {
   },
 
   shareLink(type, article, req) {
+    const twitterCharacterMax = 240 - 17; // minus 17 characters to account for @participedia and elipsis
     const url = currentUrl(req);
-    const title = article.title;
+    const title = () => {
+      const articleTitle = article.title;
+      if (articleTitle.length >= twitterCharacterMax) {
+        return articleTitle.substring(0, twitterCharacterMax) + "...";
+      } else {
+        return articleTitle;
+      }
+    };
     const shareUrls = {
       facebook: `https://www.facebook.com/sharer/sharer.php?u=${url}`,
-      twitter: `https://twitter.com/intent/tweet?text=.@participedia: ${encodeURIComponent(
-        title
-      )}&url=${url}`,
-      linkedIn: `https://www.linkedin.com/shareArticle?mini=true&url=${url}&title=${title}`,
+      twitter:
+        `https://twitter.com/intent/tweet?` +
+        `text=${encodeURIComponent(title())} @participedia&url=${url}`,
+      linkedIn:
+        `https://www.linkedin.com/shareArticle?mini=true` +
+        `&url=${url}&title=${article.title}`,
     };
     return shareUrls[type];
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the twitter share text to put the `@participedia` tag after the title, and truncate the title and add an ellipsis if it is over the allowed character count.

## Context/Issue Link
https://github.com/participedia/usersnaps/issues/986

## Screenshots (if it's a frontend change)
<img width="696" alt="Screen Shot 2020-02-18 at 3 26 08 PM" src="https://user-images.githubusercontent.com/130878/74787805-efb44f00-5264-11ea-815e-1d99f86706ef.png">
<img width="679" alt="Screen Shot 2020-02-18 at 3 26 38 PM" src="https://user-images.githubusercontent.com/130878/74787808-f2af3f80-5264-11ea-8303-974101f5c819.png">

