### PR TITLE
fix layout bug on small screens on reader pages

### DIFF
--- a/public/css/reader-view.css
+++ b/public/css/reader-view.css
@@ -86,7 +86,7 @@ article .reader-view-social-links {
   padding-right: 20px;
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1200px) {
   .edit-history-accordion {
     margin-bottom: 0;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fix layout bug so data column and content column never stack on each other

## Context/Issue Link
https://github.com/participedia/usersnaps/issues/964

## Screenshots (if it's a frontend change)
before:
![image](https://user-images.githubusercontent.com/130878/74789085-80405e80-5268-11ea-8dc5-603e3d7be9fa.png)

after:
<img width="980" alt="Screen Shot 2020-02-18 at 4 05 59 PM" src="https://user-images.githubusercontent.com/130878/74789102-92220180-5268-11ea-8224-3ad377cd1bf7.png">


