### PR TITLE
Links are supposed to be black, not blue in article body

### DIFF
--- a/public/css/reader-view.css
+++ b/public/css/reader-view.css
@@ -8,6 +8,9 @@
 
 .reader-view article a {
   overflow-wrap: break-word;
+
+  /* `!important` is needed here to override inline styles created by the quill editor */
+  color: #000!important; 
 }
 
 .reader-view dt {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
hyperlinks are supposed to be black, not blue in article body.

## Context/Issue Link
https://github.com/participedia/usersnaps/issues/988
