### PR TITLE
Update migration script to use single environment variable (DATABASE_URL)

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,9 +131,7 @@
     "resetprodfunctions": "psql -d \"${DATABASE_PROD_URL}\" -f migrations/functions.sql",
     "reset-i18n-staging-functions": "psql -d \"${DATABASE_I18N_STAGING_URL}\" -f migrations/functions.sql",
     "textdump": "pg_dump --format=p --file=one_schema.sql --clean --create --no-owner --if-exists --dbname=participedia",
-    "migrateprodlatest": "f(){ psql -d \"${DATABASE_PROD_URL}\" -f \"migrations/migration_048.sql\"; };f",
-    "migratestagelatest": "f(){ psql -d \"${DATABASE_STAGE_URL}\" -f \"migrations/migration_048.sql\"; };f",
-    "migratelocallatest": "f(){ psql -d \"${DATABASE_URL}\" -f \"migrations/migration_048.sql\"; };f",
+    "migratelatest": "f(){ psql -d \"${DATABASE_URL}\" -f \"migrations/migration_048.sql\"; };f",
     "migratetest": "f(){ psql -d \"${DATABASE_TEST_URL}\" -f \"migrations/migration_${item}.sql\"; };f",
     "migrate-i18n-staging": "f(){ psql -d \"${DATABASE_I18N_STAGING_URL}\" -f \"migrations/migration_${item}.sql\"; };f"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On Heroku, Postgres URL (DATABASE_URL) is dynamic. We shouldn't need to copy the same thing into the other 2 environment variables `DATABASE_STAGE_URL` and `DATABASE_PROD_URL`. Those should just be for local testing. So I need to change the `migratelatest` script, which we only run on Heroku, accordingly.

## How has this been tested? How can it be tested?
Cannot test until it's on stage at least. Test it by running `npm run migratelatest` on Heroku.

