### PR TITLE
Fix sorting collection

### DIFF
--- a/api/controllers/collection.js
+++ b/api/controllers/collection.js
@@ -141,10 +141,8 @@ async function postCollectionUpdateHttp(req, res) {
     newCollection.post_date = Date.now();
   }
 
-  // if this is a new collection, we don't have a updated_date yet, so we set it here
-  if (!newCollection.updated_date) {
-    newCollection.updated_date = Date.now();
-  }
+  // Override updated_date from request because the field in the client is not editable.
+  newCollection.updated_date = Date.now();
 
   // save any changes to the user-submitted text
   const {


### PR DESCRIPTION
Override updated_date from request because the field in the client is not editable. The reason why the sorting broke is because there's a field in edit/create form named `updated_date`. And formated to `YYYY-MM-DD`. When the form got submitted, the time is saved to the database is always midnight because the format received by the API is only date. no time.

https://github.com/participedia/usersnaps/issues/1031