### PR TITLE
Fix search filters section labels/buttons to use translation key

### DIFF
--- a/api/helpers/search-filters-list.js
+++ b/api/helpers/search-filters-list.js
@@ -1,13 +1,11 @@
 const searchFiltersList = {
   method: [
     {
-      sectionKey: "Type & Purpose",
-      sectionLabel: "Type & Purpose",
+      sectionKey: "type_purpose_sectionlabel",
       fieldNameKeys: ["method_types", "purpose_method", "public_spectrum"],
     },
     {
-      sectionKey: "Participants",
-      sectionLabel: "Participants",
+      sectionKey: "participants",
       fieldNameKeys: [
         "open_limited",
         "recruitment_method",
@@ -15,8 +13,7 @@ const searchFiltersList = {
       ],
     },
     {
-      sectionKey: "Process",
-      sectionLabel: "Process",
+      sectionKey: "process",
       fieldNameKeys: [
         "facetoface_online_or_both",
         "facilitators",
@@ -25,8 +22,7 @@ const searchFiltersList = {
       ],
     },
     {
-      sectionKey: "Suitable For",
-      sectionLabel: "Suitable For",
+      sectionKey: "suitable_for_sectionlabel",
       fieldNameKeys: [
         "scope_of_influence",
         "level_polarization",
@@ -35,61 +31,50 @@ const searchFiltersList = {
     },
     {
       sectionKey: "Entry Completeness",
-      sectionLabel: "Entry Completeness",
       fieldNameKeys: ["completeness"],
     },
   ],
   organizations: [
     {
-      sectionKey: "Country",
-      sectionLabel: "Country",
+      sectionKey: "country_label",
       fieldNameKeys: ["country"],
     },
     {
-      sectionKey: "Scope of Operations",
-      sectionLabel: "Scope of Operations",
+      sectionKey: "organizations_view_scope_of_influence_label",
       fieldNameKeys: ["scope_of_influence"],
     },
     {
-      sectionKey: "Focus Area",
-      sectionLabel: "Focus Area",
+      sectionKey: "focus_areas_sectionlabel",
       fieldNameKeys: ["sector", "general_issues"],
     },
     {
-      sectionKey: "Process",
-      sectionLabel: "Process",
+      sectionKey: "process",
       fieldNameKeys: ["type_method", "type_tool"],
     },
     {
       sectionKey: "Entry Completeness",
-      sectionLabel: "Entry Completeness",
       fieldNameKeys: ["completeness"],
     }
   ],
   case: [
     {
       sectionKey: "issues",
-      sectionLabel: "Issues",
       fieldNameKeys: ["general_issues"],
     },
     {
-      sectionKey: "location",
-      sectionLabel: "Location",
+      sectionKey: "country_label",
       fieldNameKeys: ["country", "scope_of_influence"],
     },
     {
       sectionKey: "purpose_and_approach",
-      sectionLabel: "Purpose & Approach",
       fieldNameKeys: ["purposes", "approaches", "public_spectrum"],
     },
     {
       sectionKey: "participants",
-      sectionLabel: "Participants",
       fieldNameKeys: ["open_limited", "recruitment_method"],
     },
     {
       sectionKey: "process",
-      sectionLabel: "Process",
       fieldNameKeys: [
         "method_types",
         "tools_techniques_types",
@@ -98,17 +83,14 @@ const searchFiltersList = {
     },
     {
       sectionKey: "organizers_supporters",
-      sectionLabel: "Organizers & Supporters",
       fieldNameKeys: ["organizer_types", "funder_types"],
     },
     {
       sectionKey: "evidence_of_impact",
-      sectionLabel: "Evidence of Impact",
       fieldNameKeys: ["change_types"],
     },
     {
       sectionKey: "Entry Completeness",
-      sectionLabel: "Entry Completeness",
       fieldNameKeys: ["completeness"],
     },
   ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Some search filter labels were not using the correct translation keys so the labels were displaying in english in other languages. 

before: 
<img width="1431" alt="Screen Shot 2020-08-19 at 5 57 57 PM" src="https://user-images.githubusercontent.com/130878/90704960-b5912d80-e246-11ea-87ed-546fc3cc9fae.png">
<img width="1434" alt="Screen Shot 2020-08-19 at 5 57 51 PM" src="https://user-images.githubusercontent.com/130878/90704964-b629c400-e246-11ea-9517-2ac2cb97fc3a.png">
<img width="958" alt="Screen Shot 2020-08-19 at 5 57 43 PM" src="https://user-images.githubusercontent.com/130878/90704967-b75af100-e246-11ea-8734-ce629b595672.png">


after:
<img width="1423" alt="Screen Shot 2020-08-19 at 6 04 39 PM" src="https://user-images.githubusercontent.com/130878/90704936-a6aa7b00-e246-11ea-8d63-878193059961.png">
<img width="1440" alt="Screen Shot 2020-08-19 at 6 04 35 PM" src="https://user-images.githubusercontent.com/130878/90704937-a7431180-e246-11ea-8cbd-5e0e5bc69a7e.png">


<img width="1435" alt="Screen Shot 2020-08-19 at 6 04 44 PM" src="https://user-images.githubusercontent.com/130878/90704932-a5794e00-e246-11ea-92e6-08feefb7de0a.png">
