### PR TITLE
search modal styling fixes

### DIFF
--- a/public/css/modal.css
+++ b/public/css/modal.css
@@ -39,18 +39,6 @@ body.modal-open {
   z-index: 10; /* this should be more than enough... */
 }
 
-@media (max-width: 1000px) {
-  .a11y-modal {
-    width: 65%;
-  }
-}
-
-@media screen and (max-width: 700px) {
-  .a11y-modal {
-    width: 90%;
-  }
-}
-
 .aria-modal-document {
   padding: 20px 40px 20px 20px;
 }
@@ -127,4 +115,34 @@ body.modal-open {
 
 .aria-modal-content {
   margin-bottom: 20px;
+}
+
+.aria-modal-content::-webkit-scrollbar {
+  width: 8px;
+  border: none;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #e6e6e6;
+  border-radius: 5px;
+  transition: all 0.5s;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #808080;
+  transition: all 0.5s;
+}
+
+@media (max-width: 1200px) {
+  .a11y-modal {
+    width: 65%;
+  }
+}
+
+@media screen and (max-width: 700px) {
+  .a11y-modal {
+    width: calc(100VW - 90px);
+  }
+  .aria-modal-document {
+    height: calc(100VH - 90px);
+  }
 }

--- a/public/css/search-filter-list.css
+++ b/public/css/search-filter-list.css
@@ -1,79 +1,64 @@
 #search-filter-modal {
   overflow: unset;
+  height: calc(100VH - 90px);
 }
 
-#search-filter-modal .aria-modal-document {
-  max-height: calc(100vh - 3.5rem);
+.search-filter-modal__document {
   display: flex;
   flex-direction: column;
-  padding: 0 !important;
-}
-
-#search-filter-modal .aria-modal-document .aria-modal-header,
-#search-filter-modal .aria-modal-document .aria-modal-footer {
-  padding: 20px;
-}
-
-#search-filter-modal .aria-modal-document .aria-modal-content {
-  padding-left: 20px;
-  margin-right: 20px;
-  overflow-y: scroll;
-}
-
-#search-filter-modal .aria-modal-document .aria-modal-content::-webkit-scrollbar {
-  width: 8px;
-  border: none;
-}
-#search-filter-modal .aria-modal-document .aria-modal-content::-webkit-scrollbar-track {
-  
-}
-::-webkit-scrollbar-thumb {
-  background: #e6e6e6;
-  border-radius: 5px;
-  transition: all 0.5s;
-}
-::-webkit-scrollbar-thumb:hover {
-  background: #808080;
-  transition: all 0.5s;
-}
-
-#search-filter-modal .aria-modal-document .aria-modal-footer {
-  border-top: 1px solid #e6e6e6;
-  display: flex !important;
   justify-content: space-between;
+  height: 100%;
+  padding: 0;
 }
 
-#search-filter-modal .aria-modal-document .aria-modal-footer .search-filter-modal-clear-btn {
+.search-filter-modal__header {
+  padding: 15px 15px 0 15px;
+}
+
+.search-filter-modal__footer {
+  border-top: 1px solid #e6e6e6;
+  min-height: 75px;
+}
+
+.search-filter-modal__footer-inner {
+  display: flex;
+  justify-content: space-between;
+  padding: 15px;
+}
+
+.search-filter-modal__content {
+  overflow-y: scroll;
+  flex: 1;
+  padding: 15px;
+  margin-right: 15px;
+}
+
+.search-filter-modal-clear-btn {
   background: none;
   border: none;
   text-decoration: underline;
 }
 
-#search-filter-modal .aria-modal-document .is-icon-btn {
-  right: 45px;
-  top: 28px;
-}
-
-.search-filter-list .search-filter-list-item {
+.search-filter-list-item {
 	margin-bottom: 60px;
 }
 
-.search-filter-list .search-filter-list-item:last-child {
+.search-filter-list-item:last-child {
 	margin-bottom: 0;
 }
 
-.search-filter-list .search-filter-list-item .filter-label {
+.search-filter-list-item .filter-label {
 	margin-bottom: 10px;
 }
 
-.search-filter-list .search-filter-list-item .filter-label label {
+.search-filter-list-item .filter-label label {
 	font-size: 1.25rem;
 	line-height: 1rem;
 	font-weight: 600;
 	display: inline-block;
 }
 
-.search-filter-list .search-filter-list-item .keys-list {
+.search-filter-list-item .keys-list {
 	display: flex;
   flex-wrap: wrap;
 
@@ -81,32 +66,31 @@
   margin-bottom: 0;
 }
 
-.search-filter-list .search-filter-list-item .keys-list .keys-list-item label {
+.search-filter-list-item .keys-list .keys-list-item label {
   font-size: 16px !important;
 }
 
-.search-filter-list .search-filter-list-item .keys-list .keys-list-item label:after {
+.search-filter-list-item .keys-list .keys-list-item label:after {
   content: "";
 }
 
-.search-filter-list .search-filter-list-item .keys-list .keys-list-item {
+.search-filter-list-item .keys-list .keys-list-item {
 	flex: 0 0 50%;
 }
 
-.search-filter-list .search-filter-list-item .keys-list .hidden {
+.search-filter-list-item .keys-list .hidden {
 	display: none;
 }
 
-.search-filter-list .search-filter-list-item .keys-list input {
+.search-filter-list-item .keys-list input {
   margin-top: 5px;
   margin-right: 5px;
   width: 20px;
   float: left;
 }
 
-#search-filter-modal,
-.search-filter-list .search-filter-list-item .search-filter-autocomplete,
-.search-filter-list .search-filter-autocomplete-list {
+.search-filter-list-item .search-filter-autocomplete,
+.search-filter-autocomplete-list {
   width: 60%;
 }
 
@@ -115,19 +99,31 @@
   width: 90%;
 }
 
-@media (max-width: 800px) {
-  .keys-list label {
-    width: 85%;
-  }
-}
-
 @media screen and (max-width: 850px) {
-  #search-filter-modal,
   .search-filter-list .search-filter-list-item .search-filter-autocomplete,
   .search-filter-list .search-filter-autocomplete-list {
     width: 90%;
   }
   .search-filter-list .search-filter-list-item .keys-list .keys-list-item {
     flex: 0 0 100%;
+  }
+}
+
+@media (max-width: 800px) {
+  .keys-list label {
+    width: 85%;
+  }
+}
+
+@media screen and (max-width: 700px) {
+  #search-filter-modal {
+    height: calc(100VH - 90px);
+  }
+}
+
+/* hack to make sure show results button is visible on mobile safari */
+@media screen and (max-width: 500px) and and (-webkit-min-device-pixel-ratio: 2) {
+  .search-filter-modal__footer-inner {
+    margin-bottom: 45px;
   }
 }

--- a/views/partials/search-filter-modal.html
+++ b/views/partials/search-filter-modal.html
@@ -1,16 +1,18 @@
 <div id="search-filter-modal" data-modal>
-  <div class="aria-modal-document" data-modal-document>
-    <div class="aria-modal-header">
+  <div class="aria-modal-document search-filter-modal__document" data-modal-document>
+    <div class="aria-modal-header search-filter-modal__header">
       <h2>{{getSearchFilterTitle type}}</h2>
     </div>
-    <div class="aria-modal-content" data-modal-content>
+    <div class="aria-modal-content search-filter-modal__content" data-modal-content>
       {{> search-filter-list type=type}}
     </div>
-    <div class="aria-modal-footer" data-modal-footer>
-      <button type="button" class="js-search-filter-modal-clear-btn search-filter-modal-clear-btn">{{t "Clear All"}}</button>
-      <button type="button" class="js-search-filter-modal-show-result-btn button button-red">
-        {{t "Show Results"}}
-      </button>
+    <div class="aria-modal-footer search-filter-modal__footer" data-modal-footer>
+      <div class="search-filter-modal__footer-inner">
+        <button type="button" class="js-search-filter-modal-clear-btn search-filter-modal-clear-btn">{{t "Clear All"}}</button>
+        <button type="button" class="js-search-filter-modal-show-result-btn button button-red">
+          {{t "Show Results"}}
+        </button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
- fix bug on safari where show all results button was not visible behind the browser chrome
- moved some modal specific styles out of search filters css to modal css

before: 
![image](https://user-images.githubusercontent.com/130878/98885301-a20cf180-2446-11eb-8312-6f747b45d750.png)

need to deploy to staging in order to test on mobile safari
