### PR TITLE
add csv download button to search screen (and fix bug with search filters button showing on collections pages)

### DIFF
--- a/api/helpers/handlebars-helpers.js
+++ b/api/helpers/handlebars-helpers.js
@@ -1372,20 +1372,17 @@ module.exports = {
   },
 
   showCsvButtonOnSearch(req) {
-    // const category = req.query.selectedCategory || null;
-    // const allowedCategories = ["case", "organizations", "method"];
-    // return (
-    //   allowedCategories.indexOf(category) >= 0 &&
-    //   req.baseUrl.indexOf("collections") > 0
-    // );
-
-    // do not show CSV download button for now
-    return false;
+    const category = req.query.selectedCategory || null;
+    console.log("req.query.selectedCategory", req.query.selectedCategory)
+    const allowedCategories = ["case", "organizations", "method"];
+    return (
+      allowedCategories.indexOf(category) >= 0 &&
+      req.baseUrl.indexOf("collection") < 0
+    );
   },
 
   includeSearchFilters(req) {
-    const category = req.query.selectedCategory || null;
-    const allowedCategories = ["case", "organizations", "method"];
-    return allowedCategories.indexOf(category) >= 0;
-  },
+    // do not show search filters on collection pages
+    return req.baseUrl.indexOf("collection") < 0;
+  }
 };

--- a/views/partials/tabs-with-cards.html
+++ b/views/partials/tabs-with-cards.html
@@ -1,6 +1,8 @@
 <div data-card-layout="{{cardLayoutType req}}">
   <div class="tab-buttons-container">
-    {{> search-filter-button }}
+    {{#if (includeSearchFilters req)}}
+      {{> search-filter-button }}
+    {{/if}}
     {{#if (showCsvButtonOnSearch req)}}
       <button class="button button-bordered-grey download-csv-btn js-download-csv-btn">
         <span class="sr-only">{{t "download"}}</span>


### PR DESCRIPTION
- show csv download button on case, method, org tabs on search
- don't show search filters button on collections pages(fixes https://github.com/participedia/usersnaps/issues/1289)

![Screen Shot 2020-11-12 at 11 00 34 AM](https://user-images.githubusercontent.com/130878/98984066-894c1c80-24d6-11eb-9a37-6e0198f13765.png)
