### PR TITLE
increase limit on featured entries on homepage

### DIFF
--- a/api/controllers/home.js
+++ b/api/controllers/home.js
@@ -112,7 +112,7 @@ router.get("/", async function(req, res) {
   // Collect Featured Things
   let featuredEntries = await db.any(FEATURED, {
     language: language,
-    limit: 7,
+    limit: 13,
     sortby: "post_date",
     type: "things",
     userId: req.user ? req.user.id : null,


### PR DESCRIPTION
increase limit on featured entries to pull a total of 12 entries between collections and case/methods/orgs.
