### PR TITLE
adjust styling of home screen for smaller resolutions

### DIFF
--- a/public/css/home.css
+++ b/public/css/home.css
@@ -43,11 +43,11 @@
 }
 
 .home-hero-header {
-  font-size: 2rem;
-  line-height: 2.3rem;
+  font-size: 28px;
+  line-height: 34px;
   color: #fff;
   width: 66%;
-  margin-bottom: 75px;
+  margin-bottom: 45px;
   font-weight: 900;
   text-shadow: 0px 0px 15px rgba(0,0,0,.5); 
   padding-top: 60px;
@@ -59,7 +59,7 @@
 
 .home-hero-stats__stat-item {
   border-right: 4px solid #fff;
-  padding: 30px 2VW 25px 2VW;
+  padding: 10px 30px 8px 30px;
 }
 .home-hero-stats__stat-item:first-child {
   padding-left: 0;
@@ -85,16 +85,16 @@
 }
 
 .home-hero-stats__stat-item h5 {
-  font-size: 3rem;
-  line-height: 2.75rem;
+  font-size: 50px;
+  line-height: 50px;
 }
 .home-hero-stats__stat-item h3 {
-  font-size: 1.25rem;
+  font-size: 20px;
   text-transform: uppercase;
 }
 
 .home-hero-search__form {
-  margin-top: 60px;
+  margin-top: 45px;
   margin-bottom: 15px;
   display: flex;
   flex-direction: row;
@@ -164,6 +164,15 @@
   margin-bottom: 0px;
 }
 
+.home-hero-image-credit__country {
+  font-size: 14px;
+  font-weight: 300;
+  margin-top: 4px;
+}
+.home-hero-image-credit__entry-link {
+  font-size: 20px;
+}
+
 .home-hero-image-credit svg {
   margin-top: 2px;
   margin-right: 4px;
@@ -172,6 +181,8 @@
 .home-hero-image-credit__credit {
   margin-top: 4px;
   display: inline-block;
+  font-weight: 300;
+  font-size: 14px;
 }
 
 .home-hero__carousel-navigation {
@@ -189,7 +200,7 @@
 }
 
 .home-hero-footer {
-  margin-bottom: 60px;
+  margin-bottom: 40px;
 }
 
 .home-hero-footer .grid-column {
@@ -200,10 +211,7 @@
   width: 80%
 }
 
-@media (max-height: 750px) { 
-  .home-hero-search__form {
-    display: none;
-  }
+@media (max-height: 598px) { 
   .home-hero-stats {
     justify-content: flex-start;
     flex-wrap: wrap;
@@ -240,11 +248,8 @@
   }
   .home-hero-header {
     width: 100%;
-    padding-top: 30px;
-    margin-bottom: 60px;
-  }
-  .home-hero-footer {
-    margin-bottom: 30px;
+    padding-top: 40px;
+    margin-bottom: 45px;
   }
 }
 @media (max-width: 1200px) { 
@@ -327,19 +332,16 @@
   }
   .home-hero-search__form-input {
     margin-right: 0;
-    margin-bottom: 15px;
+    margin-bottom: 10px;
     max-width: 325px;
   }
   .home-hero-browse-all-link {
     margin-left: 0;
-    margin-top: 15px;
-  }
-  .home-hero-browse-all-link {
-    display: none;
+    margin-top: 10px;
   }
   .home-hero-header {
-    font-size: 1.2rem;
-    line-height: 1.5rem;
+    font-size: 24px;
+    line-height: 28px;
   }
 }
 
@@ -360,4 +362,25 @@
   .home-hero__carousel-navigation {
     display: none;
   }
+  .home-hero-header {
+    padding-top: 40px;
+    font-size: 20px;
+    line-height: 24px;
+  }
+  .home-hero-image-credit__credit {
+    font-size: 10px;
+  }
+  .home-hero-image-credit__country {
+    font-size: 10px;
+  }
+  .home-hero-image-credit__entry-link {
+    font-size: 16px;
+    line-height: 20px;
+  }
+  /* .home-hero-search__form-inputs {
+    display: none;
+  }
+  .home-hero-search__form button {
+    display: none;
+  } */
 }

--- a/public/css/home.css
+++ b/public/css/home.css
@@ -94,7 +94,7 @@
 }
 
 .home-hero-search__form {
-  margin-top: 45px;
+  margin-top: 47px;
   margin-bottom: 15px;
   display: flex;
   flex-direction: row;
@@ -251,6 +251,9 @@
     padding-top: 40px;
     margin-bottom: 45px;
   }
+  .home-hero-search__form {
+    display: none;
+  }
 }
 @media (max-width: 1200px) { 
   .home-hero-header {
@@ -377,10 +380,4 @@
     font-size: 16px;
     line-height: 20px;
   }
-  /* .home-hero-search__form-inputs {
-    display: none;
-  }
-  .home-hero-search__form button {
-    display: none;
-  } */
 }

--- a/views/home.html
+++ b/views/home.html
@@ -94,11 +94,11 @@
             <h3 class="home-hero-image-credit js-home-hero-image-credit">
               <a
                 href="{{heroFeatures.0.entryUrl}}"
-                class="js-home-hero-image-credit__entry-link"
+                class="js-home-hero-image-credit__entry-link home-hero-image-credit__entry-link"
                 >{{t heroFeatures.0.entryTitle}}</a
               >
             </h3>      
-            <div class="js-home-hero-image-credit__country">{{heroFeatures.0.country}}</div>
+            <div class="js-home-hero-image-credit__country home-hero-image-credit__country">{{heroFeatures.0.country}}</div>
             {{#if heroFeatures.0.imageCredit}}
               <small 
                 class="home-hero-image-credit__credit js-home-hero-image-credit__credit" 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- make the desktop layout on the home page work at smaller resolutions/screensizes
- add the search bar back for most mobile experiences. it does not fit on the smallest 1st gen SE currently, but does on most sizes up from that

## Context/Issue Link
https://github.com/participedia/usersnaps/issues/1277
https://github.com/participedia/usersnaps/issues/1296


## Screenshots

![Screen Shot 2020-12-04 at 12 14 14 PM](https://user-images.githubusercontent.com/130878/101211021-59062280-362b-11eb-8eb1-0a87622b25a9.png)
![Screen Shot 2020-12-04 at 12 13 47 PM](https://user-images.githubusercontent.com/130878/101211027-5c011300-362b-11eb-9b38-80bbce6056ed.png)
![Screen Shot 2020-12-04 at 12 11 29 PM](https://user-images.githubusercontent.com/130878/101211029-5c99a980-362b-11eb-8a0d-d0a38d7d2d4e.png)
![Screen Shot 2020-12-04 at 12 11 17 PM](https://user-images.githubusercontent.com/130878/101211031-5d324000-362b-11eb-9710-d01266a30481.png)
<img width="1392" alt="Screen Shot 2020-12-04 at 12 28 45 PM" src="https://user-images.githubusercontent.com/130878/101211629-51934900-362c-11eb-8ad7-0edb515a02b5.png">
![Screen Shot 2020-12-04 at 12 11 11 PM](https://user-images.githubusercontent.com/130878/101211034-5dcad680-362b-11eb-8585-dadf8d7efb4c.png)
![Screen Shot 2020-12-04 at 12 10 58 PM](https://user-images.githubusercontent.com/130878/101211037-5efc0380-362b-11eb-8905-8ba30e2fce28.png)
![Screen Shot 2020-12-04 at 12 10 47 PM](https://user-images.githubusercontent.com/130878/101211042-602d3080-362b-11eb-8234-205d75d5c781.png)

