### PR TITLE
add admin only section on user profile page to display user email address

### DIFF
--- a/public/css/user.css
+++ b/public/css/user.css
@@ -39,6 +39,12 @@
   margin-top: -160px;
 }
 
+.user-view-admin-only-section {
+  padding: 20px;
+  background-color: #F8F8F8;
+  margin-bottom: 60px;
+}
+
 /* user-edit */
 .user-edit-container {
   margin-bottom: 0;

--- a/views/user-view.html
+++ b/views/user-view.html
@@ -21,6 +21,13 @@
       </br>
     {{/if}}
     {{#if profile.bio}}<div class="user-view-bio">{{{profile.bio}}}</div>{{/if}}
+
+    {{#if req.user.isadmin}}
+      <div class="user-view-admin-only-section">
+        <h2>Admin only</h2>
+        <p><strong>user email:</strong> {{profile.email}}</p>
+      </div>
+    {{/if}}
   </div>
 </div>
 <div class="user-view-body">


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
add admin only section on user profile page to display user email address

## Context/Issue Link
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/participedia/usersnaps/issues/1301

![Screen Shot 2020-12-04 at 2 37 24 PM](https://user-images.githubusercontent.com/130878/101222502-c1123400-363e-11eb-8f4e-eb0b804387e5.png)
