### PR TITLE
change breakpoint for hiding language selector in header on small screens

### DIFF
--- a/public/css/header.css
+++ b/public/css/header.css
@@ -366,7 +366,7 @@ header .right-col {
   }
 }
 
-@media (max-width: 400px) {
+@media (max-width: 385px) {
   .header-buttons .language-selector {
     display: none;
   }


### PR DESCRIPTION
language selector in header will now be visible on screens larger than 385px wide.

fixes: https://github.com/participedia/usersnaps/issues/1333