### PR TITLE
Added Google Tag Manager code for tracking user interactions

### DIFF
--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -12,6 +12,14 @@
     gtag('config', 'G-YFH69P7J7K');
   </script>
   <!-- End Google Analytics -->
+
+ <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5ZLR66MZ');</script>
+    <!-- End Google Tag Manager -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="shortcut icon" href="/favicon.ico">
@@ -36,6 +44,10 @@
 {{> modal }}
 
 <body data-view="{{params.view}}">
+  <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5ZLR66MZ"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
   {{> header }}
   <main class="main-content">
     {{!-- {{> banner-notice }} --}}


### PR DESCRIPTION
This update integrates Google Tag Manager (GTM) into the Participedia project for enhanced user interaction tracking. The GTM script is added to the `<head>` and `<body>` sections, enabling better tracking of user interactions such as topic selection under "Case" and "Method" content types. This setup allows for capturing detailed analytics on user engagement, facilitating more precise data analysis on Participedia's user activities.

Key changes:
- Added GTM `<script>` to the `<head>` section for initializing GTM.
- Added GTM `<noscript>` iframe immediately after the `<body>` tag for fallback tracking in case JavaScript is disabled.
- Configured GA4 to capture events through GTM, with specific event tracking to be handled via GTM's dashboard.

This update is required to capture detailed event data on Participedia's website, such as topic selections and user engagement on content. The implementation will allow us to analyze user behavior more accurately and help tailor content to specific user groups (e.g., educators, civic participants). 

This pull request addresses the requirement for enhanced analytics as per the feedback from Participedia’s development and data analysis teams.

This change will be tested by:
1. Verifying the GTM and GA4 integration using GTM’s Preview Mode to ensure that the code is correctly firing on page loads and user interactions.
2. Using Google Analytics Realtime reports to check that events are recorded when specific interactions (such as topic selections) occur.
3. Running Tag Assistant to confirm the GTM and GA4 tags are correctly set up and triggering as expected.

Testing Instructions:
1. Use GTM's Preview Mode to simulate topic selection clicks under "Case" and "Method" content types.
2. Check GA4's Realtime dashboard to see if the events appear when these interactions are performed.
3. Review the custom events in GA4's "Events" section under "Engagement" to ensure the interactions are captured accurately.

