### PR TITLE
Track when topics are selected from either the general issues or spec…

### DIFF
--- a/public/js/edit-multi-select.js
+++ b/public/js/edit-multi-select.js
@@ -107,6 +107,7 @@ const editMultiSelect = {
     const currentList = document.querySelector(
       `.js-edit-multi-select-list[data-name=${name}]`
     );
+
     const currentSelect = document.querySelector(
       `.js-edit-multi-select[name=${name}]`
     );
@@ -137,6 +138,16 @@ const editMultiSelect = {
       !isInList() // if it's already in the list, don't append to ui
     ) {
       currentList.append(newItemHTML);
+
+if (name === 'specific_topics' || name === 'general_issues') {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        'event': 'topicSelection',
+        'topicName': selectedText,
+        'topicCategory': name,
+        'caseId': document.querySelector('form')?.getAttribute('data-id') || 'new_case'
+      });
+    }
     } else if (!hasNotReachedMax()) {
       // insert error text & open modal
       const errorText = `You can not add more than ${maxItems} items to this field.`;
@@ -192,6 +203,17 @@ const editMultiSelect = {
       listItem.style.height = "0";
       listItem.style.marginBottom = "0";
     } else {
+const name = listContainer.getAttribute('data-name');
+    if (name === 'specific_topics' || name === 'general_issues') {
+      const removedText = listItem.querySelector('span').innerText;
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        'event': 'topicRemoval',
+        'topicName': removedText,
+        'topicCategory': name,
+        'caseId': document.querySelector('form')?.getAttribute('data-id') || 'new_case'
+      });
+    }
       listContainer.removeChild(listItem);
       this.updateIndexes(e);
     }


### PR DESCRIPTION
# Track topic selections in Google Analytics

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added Google Analytics event tracking for topic selections in case forms. The changes include:
1. Added dataLayer push tracking in edit-multi-select.js for:
   - Topic selection events (when users select topics)
   - Topic removal events (when users remove topics)
2. Tracking data includes:
   - Event name ('topicSelection' or 'topicRemoval')
   - Topic name (selected/removed topic)
   - Topic category (general_issues or specific_topics)
   - Case ID

## Context/Issue Link
<!--- Why is this change required? What problem does it solve? -->
This change helps track user interactions with topic selections to understand:
- Which topics are most frequently selected
- Topic selection patterns by country
- User behavior in topic selection/removal

<!--- If it fixes an open issue, please link to the issue here. -->
Related to analytics implementation for understanding topic selection patterns

## How has this been tested? How can it be tested?
<!--- Please describe how you tested your changes and how to test the changes on staging. -->
To test:
1. Open a case edit or creation form
2. Select topics from either general issues or specific topics dropdowns
3. Remove some topics
4. Verify in Google Tag Manager preview mode that:
   - 'topicSelection' events fire when topics are selected
   - 'topicRemoval' events fire when topics are removed
   - All event parameters (topicName, topicCategory, caseId) are present

## Screenshots (if it's a frontend change)
Not applicable as this is tracking implementation without UI changes